### PR TITLE
Feature/manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ This addon aims to maintain parity with all Tooltip library features. Current su
 
 - auto (true or false. Defaults to true)
 - effectClass (none, fade, slide, or grow. Defaults to slide)
-- event (any kind of [jQuery event](https://api.jquery.com/category/events/), defaults to hover)
+- event (any kind of [jQuery event](https://api.jquery.com/category/events/) or "manual", defaults to hover)
 - place (defaults to top)
 - spacing (defaults to 10)
 - typeClass (can be any string. No default)
+- open (true or false, when `event: 'manual'`. Defaults to null)
 
 **Please note**, depending on your use case, you may have to prefix or modify the property name. For example, `effectClass`, `tooltipEffectClass` or `tooltip-effect-class`. More info is in each section below.
 
@@ -78,6 +79,18 @@ Or with dynamic content:
     {{some-img-component src=picture.url}}
   {{/link-to}}
 {{/each}}
+```
+
+To manually set the tooltip's state:
+
+```hbs
+{{#some-component
+  tooltipContent='This tooltip is triggered manually via attribute'
+  tooltipEvent='manual'
+  tooltipOpen=showTooltip
+}}
+  I'll show a tooltip if you want me to...
+{{/some-component}}
 ```
 
 ### Using as a Component

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This addon aims to maintain parity with all Tooltip library features. Current su
 - place (defaults to top)
 - spacing (defaults to 10)
 - typeClass (can be any string. No default)
-- open (true or false, when `event: 'manual'`. Defaults to null)
+- visibility (true or false, when `event: 'manual'`. No default)
 
 **Please note**, depending on your use case, you may have to prefix or modify the property name. For example, `effectClass`, `tooltipEffectClass` or `tooltip-effect-class`. More info is in each section below.
 
@@ -87,7 +87,7 @@ To manually set the tooltip's state:
 {{#some-component
   tooltipContent='This tooltip is triggered manually via attribute'
   tooltipEvent='manual'
-  tooltipOpen=showTooltip
+  tooltipVisibility=showTooltip
 }}
   I'll show a tooltip if you want me to...
 {{/some-component}}

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -41,6 +41,7 @@ export default Ember.Mixin.create({
   tooltipPlace: 'top',
   tooltipSpacing: 10,
   tooltipTypeClass: null,
+  tooltipOpen: null, // for manual-mode triggering
 
   /**
   Removes a tooltip from the DOM if the element it is attached

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -58,6 +58,9 @@ export default Ember.Mixin.create({
       tooltip.effect(null); // Remove animation
       tooltip.detach();
     }
+
+    /* Remove observer, even if it was never added */
+    this.removeObserver('tooltipOpen', this, this.tooltipOpenDidChange);
   }),
 
   /**

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -144,6 +144,23 @@ export default Ember.Mixin.create({
   }),
 
   /**
+  Opens / closes tooltip based on value of 'tooltipOpen'.
+  Only used when event is 'manual'.
+
+  @method tooltipOpenDidChange
+  */
+
+  tooltipOpenDidChange: function() {
+    const tooltip = this.get('tooltip');
+
+    if (this.get('tooltipOpen')) {
+      tooltip.show();
+    } else {
+      tooltip.hide();
+    }
+  },
+
+  /**
   Call this method on any view to attach tooltips to all elements in its
   template that have a `.tooltip` class. Tooltip options are set using
   data attributes.

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -37,7 +37,7 @@ export default Ember.Mixin.create({
   tooltipAuto: true,
   tooltipContent: null,
   tooltipEffectClass: 'slide', // fade, grow, slide, null
-  tooltipEvent: 'hover',
+  tooltipEvent: 'hover', // DOM event or "manual"
   tooltipPlace: 'top',
   tooltipSpacing: 10,
   tooltipTypeClass: null,

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -29,7 +29,8 @@ export default Ember.Mixin.create({
     'event',
     'place',
     'spacing',
-    'typeClass'
+    'typeClass',
+    'open'
   ],
 
   /* Tooltip options - see http://darsa.in/tooltip/ */
@@ -144,6 +145,12 @@ export default Ember.Mixin.create({
 
     /* Bind observer if manual-triggering mode */
     if (tooltipOptions.event === 'manual') {
+      if (componentWasPassed) {
+        // Keep track of child tooltip component
+        this.set('tooltipChildComponent', component);
+        // Turn 'tooltipOpen' into a computed property, reading from child tooltip component's 'open' option
+        Ember.defineProperty(this, 'tooltipOpen', Ember.computed.reads('tooltipChildComponent.open'));
+      }
       Ember.addObserver(this, 'tooltipOpen', this, this.tooltipOpenDidChange);
       this.tooltipOpenDidChange();
     }

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -30,7 +30,7 @@ export default Ember.Mixin.create({
     'place',
     'spacing',
     'typeClass',
-    'open'
+    'visibility'
   ],
 
   /* Tooltip options - see http://darsa.in/tooltip/ */
@@ -42,7 +42,7 @@ export default Ember.Mixin.create({
   tooltipPlace: 'top',
   tooltipSpacing: 10,
   tooltipTypeClass: null,
-  tooltipOpen: null, // for manual-mode triggering
+  tooltipVisibility: null, // for manual-mode triggering
 
   /**
   Removes a tooltip from the DOM if the element it is attached
@@ -60,7 +60,7 @@ export default Ember.Mixin.create({
     }
 
     /* Remove observer, even if it was never added */
-    this.removeObserver('tooltipOpen', this, this.tooltipOpenDidChange);
+    this.removeObserver('tooltipVisibility', this, this.tooltipVisibilityDidChange);
   }),
 
   /**
@@ -151,25 +151,25 @@ export default Ember.Mixin.create({
       if (componentWasPassed) {
         // Keep track of child tooltip component
         this.set('tooltipChildComponent', component);
-        // Turn 'tooltipOpen' into a computed property, reading from child tooltip component's 'open' option
-        Ember.defineProperty(this, 'tooltipOpen', Ember.computed.reads('tooltipChildComponent.open'));
+        // Turn 'tooltipVisibility' into a computed property, reading from child tooltip component's 'visibility' option
+        Ember.defineProperty(this, 'tooltipVisibility', Ember.computed.reads('tooltipChildComponent.visibility'));
       }
-      this.addObserver('tooltipOpen', this, this.tooltipOpenDidChange);
-      this.tooltipOpenDidChange();
+      this.addObserver('tooltipVisibility', this, this.tooltipVisibilityDidChange);
+      this.tooltipVisibilityDidChange();
     }
   }),
 
   /**
-  Opens / closes tooltip based on value of 'tooltipOpen'.
+  Opens / closes tooltip based on value of 'tooltipVisibility'.
   Only used when event is 'manual'.
 
-  @method tooltipOpenDidChange
+  @method tooltipVisibilityDidChange
   */
 
-  tooltipOpenDidChange: function() {
+  tooltipVisibilityDidChange: function() {
     const tooltip = this.get('tooltip');
 
-    if (this.get('tooltipOpen')) {
+    if (this.get('tooltipVisibility')) {
       tooltip.show();
     } else {
       tooltip.hide();

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -141,6 +141,12 @@ export default Ember.Mixin.create({
     tooltip = renderTooltip(this.get('element'), tooltipOptions);
 
     this.set('tooltip', tooltip);
+
+    /* Bind observer if manual-triggering mode */
+    if (tooltipOptions.event === 'manual') {
+      Ember.addObserver(this, 'tooltipOpen', this, this.tooltipOpenDidChange);
+      this.tooltipOpenDidChange();
+    }
   }),
 
   /**

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -154,7 +154,7 @@ export default Ember.Mixin.create({
         // Turn 'tooltipOpen' into a computed property, reading from child tooltip component's 'open' option
         Ember.defineProperty(this, 'tooltipOpen', Ember.computed.reads('tooltipChildComponent.open'));
       }
-      Ember.addObserver(this, 'tooltipOpen', this, this.tooltipOpenDidChange);
+      this.addObserver('tooltipOpen', this, this.tooltipOpenDidChange);
       this.tooltipOpenDidChange();
     }
   }),

--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -30,9 +30,11 @@ export default function renderTooltip(domElement = {}, options = {}) {
 
   tooltip.attach(domElement);
 
-  Ember.$(domElement)[options.event](function() {
-    tooltip.toggle();
-  });
+  if (options.event !== 'manual') {
+    Ember.$(domElement)[options.event](function() {
+      tooltip.toggle();
+    });
+  }
 
   return tooltip;
 }

--- a/tests/acceptance/tooltip-manual-trigger-test.js
+++ b/tests/acceptance/tooltip-manual-trigger-test.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application;
+
+module('Acceptance | tooltip triggered manually', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('Rendering tooltips with event="manual" and provided "tooltipOpen" boolean', function(assert) {
+  visit('/tooltip-manual-trigger');
+
+  assert.expect(13);
+
+  assertTooltipProperties(assert, 'manually-trigger', {
+    content: 'This is a manually triggered tooltip',
+    usingComponent: false,
+    event: 'manual'
+  });
+
+  assertTooltipProperties(assert, 'manually-trigger-component', {
+    targetContent: 'Manual tooltip as component',
+    content: 'Manually triggering a component tooltip',
+    usingComponent: true,
+    event: 'manual'
+  });
+
+});

--- a/tests/acceptance/tooltip-manual-trigger-test.js
+++ b/tests/acceptance/tooltip-manual-trigger-test.js
@@ -14,7 +14,7 @@ module('Acceptance | tooltip triggered manually', {
   }
 });
 
-test('Rendering tooltips with event="manual" and provided "tooltipOpen" boolean', function(assert) {
+test('Rendering tooltips with event="manual" and provided "tooltipVisibility" boolean', function(assert) {
   visit('/tooltip-manual-trigger');
 
   assert.expect(13);

--- a/tests/acceptance/tooltip-manual-trigger-test.js
+++ b/tests/acceptance/tooltip-manual-trigger-test.js
@@ -21,7 +21,6 @@ test('Rendering tooltips with event="manual" and provided "tooltipOpen" boolean'
 
   assertTooltipProperties(assert, 'manually-trigger', {
     content: 'This is a manually triggered tooltip',
-    usingComponent: false,
     event: 'manual'
   });
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('tooltip-as-component');
   this.route('tooltip-on-element');
   this.route('tooltip-on-helper');
+  this.route('tooltip-manual-trigger');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -21,6 +21,12 @@
     {{/link-to}}
   </li>
 
+  <li>
+    {{#link-to 'tooltip-manual-trigger'}}
+      Tooltips triggered <strong>manually</strong> by providing a <strong>boolean attribute</strong>
+    {{/link-to}}
+  </li>
+
 </ul>
 
 {{outlet}}

--- a/tests/dummy/app/templates/tooltip-manual-trigger.hbs
+++ b/tests/dummy/app/templates/tooltip-manual-trigger.hbs
@@ -6,7 +6,7 @@
     {{#test-component
       tooltipContent='This is a manually triggered tooltip'
       tooltipEvent='manual'
-      tooltipOpen=showTooltip
+      tooltipVisibility=showTooltip
       data-test='manually-trigger'
     }}
       Manual tooltip
@@ -19,7 +19,7 @@
     {{#test-component data-test='manually-trigger-component'}}
       {{#tooltip-on-parent
         event='manual'
-        open=showComponentTooltip
+        visibility=showComponentTooltip
       }}
         Manually triggering a component tooltip
       {{/tooltip-on-parent}}

--- a/tests/dummy/app/templates/tooltip-manual-trigger.hbs
+++ b/tests/dummy/app/templates/tooltip-manual-trigger.hbs
@@ -1,0 +1,32 @@
+<h2>Tooltips triggered manually</h2>
+
+<ul class="examples">
+
+  <li>
+    {{#test-component
+      tooltipContent='This is a manually triggered tooltip'
+      tooltipEvent='manual'
+      tooltipOpen=showTooltip
+      data-test='manually-trigger'
+    }}
+      Manual tooltip
+    {{/test-component}}
+
+    {{input type="checkbox" checked=showTooltip}} Show
+  </li>
+
+  <li>
+    {{#test-component data-test='manually-trigger-component'}}
+      {{#tooltip-on-parent
+        event='manual'
+        open=showComponentTooltip
+      }}
+        Manually triggering a component tooltip
+      {{/tooltip-on-parent}}
+      Manual tooltip as component
+    {{/test-component}}
+
+    {{input type="checkbox" checked=showComponentTooltip}} Show
+  </li>
+
+</ul>

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -34,6 +34,8 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       click(selectorFor(name));
     } else if (expectedEvent === 'hover') {
       mouseOver(name);
+    } else if (expectedEvent) {
+      click(selectorFor(name) + ' + input[type="checkbox"]');
     }
 
     andThen(function() {
@@ -125,7 +127,10 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       click(selectorFor(name));
     } else if (expectedEvent === 'hover') {
       mouseOut(name);
+    } else if (expectedEvent) {
+      click(selectorFor(name) + ' + input[type="checkbox"]');
     }
+
 
     /* Then check it has been removed */
 

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -34,7 +34,7 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       click(selectorFor(name));
     } else if (expectedEvent === 'hover') {
       mouseOver(name);
-    } else if (expectedEvent) {
+    } else if (expectedEvent === 'manual') {
       click(selectorFor(name) + ' + input[type="checkbox"]');
     }
 
@@ -127,7 +127,7 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       click(selectorFor(name));
     } else if (expectedEvent === 'hover') {
       mouseOut(name);
-    } else if (expectedEvent) {
+    } else if (expectedEvent === 'manual') {
       click(selectorFor(name) + ' + input[type="checkbox"]');
     }
 

--- a/tests/unit/mixins/components/tooltips-test.js
+++ b/tests/unit/mixins/components/tooltips-test.js
@@ -25,6 +25,7 @@ test('The mixin adds the public properties', function(assert) {
       'place',
       'spacing',
       'typeClass',
+      'open'
     ],
     tooltipAuto: true,
     tooltipContent: null,
@@ -33,9 +34,10 @@ test('The mixin adds the public properties', function(assert) {
     tooltipPlace: 'top',
     tooltipSpacing: null,
     tooltipTypeClass: null,
+    tooltipOpen: null,
   };
 
-  assert.expect(9);
+  assert.expect(10);
 
   Ember.keys(expectedProperties).forEach(function(expectedProperty) {
     const expectedValue = expectedProperties[expectedProperty];

--- a/tests/unit/mixins/components/tooltips-test.js
+++ b/tests/unit/mixins/components/tooltips-test.js
@@ -25,7 +25,7 @@ test('The mixin adds the public properties', function(assert) {
       'place',
       'spacing',
       'typeClass',
-      'open'
+      'visibility'
     ],
     tooltipAuto: true,
     tooltipContent: null,
@@ -34,7 +34,7 @@ test('The mixin adds the public properties', function(assert) {
     tooltipPlace: 'top',
     tooltipSpacing: null,
     tooltipTypeClass: null,
-    tooltipOpen: null,
+    tooltipVisibility: null,
   };
 
   assert.expect(10);


### PR DESCRIPTION
Hello sir-dunxalot - great plugin you got here! So many flexible usage options - the `{{tooltip-on-parent}}` with HTMLBars block for content is a great touch.

We have a use-case where we'd like to show more "permanent" tooltips on certain UI elements. I've extended your plugin to allow for manual triggering. Tried to follow your style & make clean, incremental commits.

Some notes:

* I decided to extend the `event` option after I verified that `darsain/tooltips` is not using that property. I could have made manual-mode a separate option, but since `event` is specific to this plugin, I figured `event: 'manual'` would be acceptable. Let me know if you'd prefer another approach.
* Specifying `event:'manual'` and binding `open` works for both on-component and `{{tooltip-on-parent}}` use-cases, but *not* for HTML data-attrs. Seems architecturally related to issue #5, so I didn't dive in there.

Let me know your thoughts! If I'm on a good track, I can definitely provide more tests for these features.