### PR TITLE
Tooltip durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Documentation for usage is below:
 This addon aims to maintain parity with all Tooltip library features. Current supported properties are:
 
 - auto (true or false. Defaults to true)
+- duration (time in milliseconds. No default)
 - effectClass (none, fade, slide, or grow. Defaults to slide)
 - event (any kind of [jQuery event](https://api.jquery.com/category/events/) or "manual", defaults to hover)
 - place (defaults to top)
@@ -91,6 +92,17 @@ To manually set the tooltip's state:
 }}
   I'll show a tooltip if you want me to...
 {{/some-component}}
+```
+
+Tooltips can be automatically closed:
+
+```hbs
+{{input type="text"
+  tooltipEvent="focus"
+  tooltipContent="Helpful form tip"
+  tooltipDuration="1000"
+  tooltipPlace="right"
+}}
 ```
 
 ### Using as a Component

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -25,6 +25,7 @@ export default Ember.Mixin.create({
   tooltipSupportedProperties: [
     'auto',
     'content',
+    'duration',
     'effectClass',
     'event',
     'place',
@@ -37,6 +38,7 @@ export default Ember.Mixin.create({
 
   tooltipAuto: true,
   tooltipContent: null,
+  tooltipDuration: null,
   tooltipEffectClass: 'slide', // fade, grow, slide, null
   tooltipEvent: 'hover', // DOM event or "manual"
   tooltipPlace: 'top',

--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -26,6 +26,14 @@ export default function renderTooltip(domElement = {}, options = {}) {
     options.event = 'hover';
   }
 
+  if (options.duration && typeof options.duration === 'string') {
+    options.duration = parseInt(options.duration, 10);
+    if (isNaN(options.duration) || !isFinite(options.duration)) {
+      // Remove invalid parseInt results
+      options.duration = null;
+    }
+  }
+
   tooltip = new Tooltip(options.content, options);
 
   tooltip.attach(domElement);

--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -50,7 +50,7 @@ export default function renderTooltip(domElement = {}, options = {}) {
 
       if (willShow && options.duration) {
         // Hide tooltip after specified duration
-        let hideTimer = Ember.run.later(function() {
+        const hideTimer = Ember.run.later(function() {
           tooltip.hide();
         }, options.duration);
         // Save timer id for cancelling

--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -32,7 +32,20 @@ export default function renderTooltip(domElement = {}, options = {}) {
 
   if (options.event !== 'manual') {
     Ember.$(domElement)[options.event](function() {
+      const willShow = tooltip.hidden;
+
       tooltip.toggle();
+
+      // Clean previously queued removal (if present)
+      Ember.run.cancel(tooltip._hideTimer);
+      if (willShow && options.duration) {
+        // Hide tooltip after specified duration
+        let hideTimer = Ember.run.later(function() {
+          tooltip.hide();
+        }, options.duration);
+        // Save timer id for cancelling
+        tooltip._hideTimer = hideTimer;
+      }
     });
   }
 

--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -28,6 +28,7 @@ export default function renderTooltip(domElement = {}, options = {}) {
 
   if (options.duration && typeof options.duration === 'string') {
     options.duration = parseInt(options.duration, 10);
+
     if (isNaN(options.duration) || !isFinite(options.duration)) {
       // Remove invalid parseInt results
       options.duration = null;
@@ -46,6 +47,7 @@ export default function renderTooltip(domElement = {}, options = {}) {
 
       // Clean previously queued removal (if present)
       Ember.run.cancel(tooltip._hideTimer);
+
       if (willShow && options.duration) {
         // Hide tooltip after specified duration
         let hideTimer = Ember.run.later(function() {

--- a/tests/acceptance/tooltip-auto-close-test.js
+++ b/tests/acceptance/tooltip-auto-close-test.js
@@ -1,0 +1,42 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application;
+
+module('Acceptance | tooltip auto close', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('Auto-closing tooltips using duration parameter', function(assert) {
+  visit('/tooltip-auto-close');
+
+  assert.expect(25);
+
+  assertTooltipProperties(assert, 'auto-close-basic', {
+    content: 'This shows on a click event, then hides',
+    event: 'click'
+  });
+
+  assertTooltipProperties(assert, 'auto-close-component', {
+    content: 'Using a component with duration set',
+    usingComponent: true,
+  });
+
+  assertTooltipProperties(assert, 'auto-close-data', {
+    content: 'This is set on a data attribute',
+    event: 'click'
+  });
+
+  assertTooltipProperties(assert, 'auto-close-input', {
+    content: 'Auto-closing tooltip on {{input}}',
+    event: 'focus'
+  });
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('tooltip-on-element');
   this.route('tooltip-on-helper');
   this.route('tooltip-manual-trigger');
+  this.route('tooltip-auto-close');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -27,6 +27,12 @@
     {{/link-to}}
   </li>
 
+  <li>
+    {{#link-to 'tooltip-auto-close'}}
+      Tooltips with <strong>automatic-close durations</strong>
+    {{/link-to}}
+  </li>
+
 </ul>
 
 {{outlet}}

--- a/tests/dummy/app/templates/tooltip-auto-close.hbs
+++ b/tests/dummy/app/templates/tooltip-auto-close.hbs
@@ -15,7 +15,7 @@
 
   <li>
     {{#test-component data-test='auto-close-component'}}
-      {{#tooltip-on-parent duration="1000" event="mouseenter"}}
+      {{#tooltip-on-parent duration='1000' event='mouseenter'}}
         Using a component with duration set
       {{/tooltip-on-parent}}
       Hover over me
@@ -38,12 +38,12 @@
 
   <li>
     {{input
-      type="text"
-      data-test="auto-close-input"
-      tooltipEvent="focus"
-      tooltipContent="Auto-closing tooltip on {{input}}"
-      tooltipDuration="1000"
-      placeholder="Focus field"
+      type='text'
+      data-test='auto-close-input'
+      tooltipEvent='focus'
+      tooltipContent='Auto-closing tooltip on {{input}}'
+      tooltipDuration='1000'
+      placeholder='Focus field'
     }}
   </li>
 

--- a/tests/dummy/app/templates/tooltip-auto-close.hbs
+++ b/tests/dummy/app/templates/tooltip-auto-close.hbs
@@ -1,0 +1,50 @@
+<h2>Automatically Closing Tooltips</h2>
+
+<ul class="examples">
+
+  <li>
+    {{#test-component
+      tooltipContent='This shows on a click event, then hides'
+      tooltipEvent='click'
+      data-test='auto-close-basic'
+      tooltipDuration=2000
+    }}
+      Click me
+    {{/test-component}}
+  </li>
+
+  <li>
+    {{#test-component data-test='auto-close-component'}}
+      {{#tooltip-on-parent duration="1000" event="mouseenter"}}
+        Using a component with duration set
+      {{/tooltip-on-parent}}
+      Hover over me
+    {{/test-component}}
+  </li>
+
+  <li>
+    {{#test-calling-component}}
+      <div
+        class="has-tooltip inline-block"
+        data-test="auto-close-data"
+        data-tooltip-content="This is set on a data attribute"
+        data-tooltip-event="click"
+        data-tooltip-duration="1000"
+      >
+        Click me
+      </div>
+    {{/test-calling-component}}
+  </li>
+
+  <li>
+    {{input
+      type="text"
+      data-test="auto-close-input"
+      tooltipEvent="focus"
+      tooltipContent="Auto-closing tooltip on {{input}}"
+      tooltipDuration="1000"
+      placeholder="Focus field"
+    }}
+  </li>
+
+</ul>

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -36,6 +36,8 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       mouseOver(name);
     } else if (expectedEvent === 'manual') {
       click(selectorFor(name) + ' + input[type="checkbox"]');
+    } else if (expectedEvent === 'focus') {
+      triggerEvent(selectorFor(name), 'focus');
     }
 
     andThen(function() {

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -124,8 +124,9 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
     });
 
     /* Unhover/click so the tooltip is detached from the DOM */
-
-    if (expectedEvent === 'click') {
+    if (name.match('auto-close')) {
+      // do nothing (just wait for close)
+    } else if (expectedEvent === 'click') {
       click(selectorFor(name));
     } else if (expectedEvent === 'hover') {
       mouseOut(name);

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -36,8 +36,8 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
       mouseOver(name);
     } else if (expectedEvent === 'manual') {
       click(selectorFor(name) + ' + input[type="checkbox"]');
-    } else if (expectedEvent === 'focus') {
-      triggerEvent(selectorFor(name), 'focus');
+    } else {
+      triggerEvent(selectorFor(name), expectedEvent);
     }
 
     andThen(function() {

--- a/tests/unit/mixins/components/tooltips-test.js
+++ b/tests/unit/mixins/components/tooltips-test.js
@@ -20,6 +20,7 @@ test('The mixin adds the public properties', function(assert) {
     tooltipSupportedProperties: [
       'auto',
       'content',
+      'duration',
       'effectClass',
       'event',
       'place',
@@ -29,6 +30,7 @@ test('The mixin adds the public properties', function(assert) {
     ],
     tooltipAuto: true,
     tooltipContent: null,
+    tooltipDuration: null,
     tooltipEffectClass: 'slide', // fade, grow, slide, null
     tooltipEvent: 'hover',
     tooltipPlace: 'top',
@@ -37,7 +39,7 @@ test('The mixin adds the public properties', function(assert) {
     tooltipVisibility: null,
   };
 
-  assert.expect(10);
+  assert.expect(11);
 
   Ember.keys(expectedProperties).forEach(function(expectedProperty) {
     const expectedValue = expectedProperties[expectedProperty];


### PR DESCRIPTION
I was playing around with the actions implemented in the Ember 1.13+ version of PR #9 - but trying to always use the actions was an awkward way to approach this feature.

A quick augment of the `render-tooltip` util has done nicely though - I think it's important to support the `data-attr` style for durations (which the actions didn't address, since the tooltips aren't saved).

I know you said you were going to handle #10, @sir-dunxalot, but this turned into a full feature, so I added tests and went with it. Your test helper has made it very easy to dive in! Made sure to address the specific use-case of #10 in the tests.

Kept the branches separate, too, since they don't depend on each other. Gonna have comma-conflicts if you end up merging both, but no big deal to rebase or w/e

One weird note is that the in-browser tests only work when the window is focused, due to input focus event handling (at least for me, chrome/linux). Nothing to worry about though, & phantom works nicely.
![2015-07-26-193958_1920x1080_scrot](https://cloud.githubusercontent.com/assets/489896/8897919/0451893e-33d2-11e5-86af-047da204ae53.png)
