### PR TITLE
remove 'View' from addTo array for Ember 1.13 and greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ export default Ember.Component.extend({
 
 ### Customizing the Mixin
 
-By default the `ember-tooltips` mixin is added to all views and components. This mixin contains the helper methods to render tooltips.
+By default the `ember-tooltips` mixin is added to all components. This mixin contains the helper methods to render tooltips.
 
 You can customize where the mixin is automatically added by overriding the `addTo` option in your `config/environment.js` file:
 
@@ -211,7 +211,7 @@ module.exports = function(environment) {
     /* ... */
 
     tooltips: {
-      addTo: ['View', 'Component'], // Ember.View, Ember.Component
+      addTo: ['Component'], // Ember.Component
     }
   }
 };

--- a/app/initializers/ember-tooltips.js
+++ b/app/initializers/ember-tooltips.js
@@ -6,7 +6,7 @@ import Tooltips from '../mixins/components/tooltips';
 
 export function initialize() {
   const defaultOptions = {
-    addTo: ['Component', 'View'],
+    addTo: ['Component'],
   };
   const overridingOptions = ENV.tooltips || {};
   const options = Ember.merge(defaultOptions, overridingOptions);


### PR DESCRIPTION
Ember 1.13 throws deprecation warnings because `Views` are being deprecated. This will just flat out break in Ember 2.0 unless the `View` is removed.