### PR TITLE
Fix an issue where component teardown breaks IE

### DIFF
--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -61,7 +61,7 @@ export default Ember.Mixin.create({
       tooltip.hide();
       tooltip.detach();
 
-      if (document.contains(tooltip.element)) {
+      if (document.body.contains(tooltip.element)) {
         this.$().unbind();
       }
     }


### PR DESCRIPTION
document.contains() is not available in IE, it returns an error message
"Object doesn't support property or method 'contains'", (tested on both IE10 &
IE11). Use document.body.contains() instead.