### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/sir-dunxalot/ember-tooltips",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Repository field was blank in package.json. Useful for getting to this repo from npm page etc.