### PR TITLE
Allow tooltip HTML titles to have an empty string

### DIFF
--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -217,7 +217,7 @@ export default function renderTooltip(domElement, options, context) {
 
   $domElement.attr({
     tabindex: $domElement.attr('tabindex') || tabIndex,
-    title: $domElement.attr('title') || content.toString(),
+    title: ($domElement.attr('title') === undefined) ? content.toString() : $domElement.attr('title'),
   });
 
   tooltipIndex++;


### PR DESCRIPTION
When using HTML in tooltips, it doesn't look good for that to appear in the standard HTML tag `title` attr (when hovered over the element). This allows you to set the `title` to an empty string. If it's not an empty string, it's undefined and goes back to using `content.toString()`