### PR TITLE
Remove the deprecation messages

### DIFF
--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
 
-const { computed, warn, run, get } = Ember;
+const { computed, run, get } = Ember;
 
 export default Ember.Component.extend({
   attributeBindings: ['style'],
@@ -16,12 +16,11 @@ export default Ember.Component.extend({
 
     run.schedule('afterRender', () => {
       const parentView = this.get('parentView');
-      const parentHasSelector = get(parentView, 'tagName') ? true : false;
-      const domTarget = get(parentView, 'domTarget');
-      const target = parentHasSelector ? parentView : domTarget;
-
-      if (target.renderTooltip) {
-        target.renderTooltip(this);
+      const componentNotInDOM = get(parentView, 'tagName') ? false : true;
+      if(componentNotInDOM) {
+        console.warn('The parent component of {{tooltip-on-parent}} has no tagName and therefore no position in the DOM to target');
+      } else if (parentView.renderTooltip) {
+        parentView.renderTooltip(this);
       } else {
         console.warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
+import renderTooltip from 'ember-tooltips/utils/render-tooltip';
 
 const { computed, warn, run, get } = Ember;
 
@@ -13,17 +14,19 @@ export default Ember.Component.extend({
 
   init(...args) {
     this._super(args);
-    
+
     run.schedule('afterRender', () => {
       const parentView = this.get('parentView');
 
       if (parentView.renderTooltip) {
-        const target = get(parentView, 'tooltipTarget') ? this.$().find(get(parentView, 'tooltipTarget'))[0] : this;
-        parentView.renderTooltip(target);
+        const parentHasSelector = get(parentView, 'tagName') ? true : false;
+        const domTarget = get(parentView, 'domTarget');
+        const target = parentHasSelector ? parentView : domTarget;
+        target.renderTooltip(this);
       } else {
         warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }
-      
+
       this.remove();
     });
   },

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
       const parentView = this.get('parentView');
 
       if (parentView.renderTooltip) {
-        const target = get(this, 'tooltipTarget') ? get(this, 'tooltipTarget') : this;
+        const target = get(parentView, 'tooltipTarget') ? get(parentView, 'tooltipTarget') : this;
         parentView.renderTooltip(target);
       } else {
         warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -25,9 +25,6 @@ export default Ember.Component.extend({
       
       this.remove();
     });
-    
-
-    
-  }),
+  },
 
 });

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
   }),
 
   init(...args) {
-    this._super.init(args);
+    this._super(args);
     
     run.schedule('afterRender', () => {
       const parentView = this.get('parentView');

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
 
-const { computed, on, warn, run } = Ember;
+const { computed, warn, run } = Ember;
 
 export default Ember.Component.extend({
   attributeBindings: ['style'],

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
 
-const { computed, warn, run } = Ember;
+const { computed, warn, run, get } = Ember;
 
 export default Ember.Component.extend({
   attributeBindings: ['style'],
@@ -18,7 +18,8 @@ export default Ember.Component.extend({
       const parentView = this.get('parentView');
 
       if (parentView.renderTooltip) {
-        parentView.renderTooltip(this);
+        const target = get(this, 'tooltipTarget') ? get(this, 'tooltipTarget') : this;
+        parentView.renderTooltip(target);
       } else {
         warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
-import renderTooltip from 'ember-tooltips/utils/render-tooltip';
 
 const { computed, warn, run, get } = Ember;
 

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/tooltip-on-parent';
 
-const { computed, on, warn } = Ember;
+const { computed, on, warn, run } = Ember;
 
 export default Ember.Component.extend({
   attributeBindings: ['style'],
@@ -11,16 +11,23 @@ export default Ember.Component.extend({
     return Ember.String.htmlSafe('display:none;');
   }),
 
-  registerOnParent: on('didInsertElement', function() {
-    const parentView = this.get('parentView');
+  init(...args) {
+    this._super.init(args);
+    
+    run.schedule('afterRender', () => {
+      const parentView = this.get('parentView');
 
-    if (parentView.renderTooltip) {
-      parentView.renderTooltip(this);
-    } else {
-      warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
-    }
+      if (parentView.renderTooltip) {
+        parentView.renderTooltip(this);
+      } else {
+        warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
+      }
+      
+      this.remove();
+    });
+    
 
-    this.remove();
+    
   }),
 
 });

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -16,14 +16,14 @@ export default Ember.Component.extend({
 
     run.schedule('afterRender', () => {
       const parentView = this.get('parentView');
+      const parentHasSelector = get(parentView, 'tagName') ? true : false;
+      const domTarget = get(parentView, 'domTarget');
+      const target = parentHasSelector ? parentView : domTarget;
 
-      if (parentView.renderTooltip) {
-        const parentHasSelector = get(parentView, 'tagName') ? true : false;
-        const domTarget = get(parentView, 'domTarget');
-        const target = parentHasSelector ? parentView : domTarget;
+      if (target.renderTooltip) {
         target.renderTooltip(this);
       } else {
-        warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
+        console.warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }
 
       this.remove();

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
       const parentView = this.get('parentView');
 
       if (parentView.renderTooltip) {
-        const target = get(parentView, 'tooltipTarget') ? get(parentView, 'tooltipTarget') : this;
+        const target = get(parentView, 'tooltipTarget') ? this.$().find(get(parentView, 'tooltipTarget'))[0] : this;
         parentView.renderTooltip(target);
       } else {
         warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -62,7 +62,7 @@ export default Ember.Mixin.create({
   destroyTooltip: on('willDestroyElement', function() {
     const tooltip = this.get('tooltip');
 
-    if (tooltip) {
+    if (tooltip && Ember.typeOf(tooltip) === 'object') {
       tooltip.effect(null); // Remove animation
       tooltip.detach();     // Remove the tooltip from the document
       this.$().off();       // Remove all event listeners


### PR DESCRIPTION
By switching to `init()` (within a "afterRender" schedule) we can avoid the ugly deprecations that often creep into `didInsertElement`.