### PR TITLE
Fix applying of typeClass as defined by vendor css

### DIFF
--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -100,7 +100,7 @@ export default function renderTooltip(domElement, options, context) {
     /* Prefix type class */
 
     if (typeClass) {
-      newOptions.typeClass = 'tooltip-' + typeClass;
+      newOptions.typeClass = typeClass;
     }
 
     /* Set the correct hide and show events */

--- a/tests/acceptance/tooltip-with-type-class-test.js
+++ b/tests/acceptance/tooltip-with-type-class-test.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+
+module('Acceptance | tooltip with type class', {
+  beforeEach() {
+    this.application = startApp();
+  },
+
+  afterEach() {
+    Ember.run(this.application, 'destroy');
+  },
+});
+
+test('Tooltips can have a type class assigned', function(assert) {
+  visit('/tooltip-with-type-class');
+
+  assertTooltipProperties(assert, 'with-type-class-light', {
+    content: 'This is a tooltip with a type class "light"',
+    typeClass: 'light',
+  });
+
+  assertTooltipProperties(assert, 'with-type-class-success', {
+    content: 'This is a tooltip with a type class "success"',
+    typeClass: 'success',
+  });
+
+  assertTooltipProperties(assert, 'with-type-class-warning', {
+    content: 'This is a tooltip with a type class "warning"',
+    typeClass: 'warning',
+  });
+
+  assertTooltipProperties(assert, 'with-type-class-error', {
+    content: 'This is a tooltip with a type class "error"',
+    typeClass: 'error',
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
   this.route('tooltip-manual-trigger');
   this.route('tooltip-auto-close');
   this.route('tooltip-with-safestring');
+  this.route('tooltip-with-type-class');
 });
 
 export default Router;

--- a/tests/dummy/app/snippets/tooltip-with-type-class.hbs
+++ b/tests/dummy/app/snippets/tooltip-with-type-class.hbs
@@ -1,0 +1,17 @@
+{{!-- BEGIN-SNIPPET tooltip-with-type-class --}}
+{{test-component
+  tooltipContent='This is a tooltip with a type class "light"'
+  tooltipTypeClass='light'}}
+
+{{test-component
+  tooltipContent='This is a tooltip with a type class "success"'
+  tooltipTypeClass='success'}}
+
+{{test-component
+  tooltipContent='This is a tooltip with a type class "warning"'
+  tooltipTypeClass='warning'}}
+
+{{test-component
+  tooltipContent='This is a tooltip with a type class "error"'
+  tooltipTypeClass='error'}}
+{{!-- END-SNIPPET --}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -40,6 +40,10 @@
           Automatic close durations
         {{/paper-item}}
 
+        {{#paper-item action='transitionTo' param='tooltip-with-type-class'}}
+          Specifying a type class
+        {{/paper-item}}
+
         {{paper-divider}}
 
         {{#paper-item action='linkTo' param='https://github.com/sir-dunxalot/ember-tooltips'}}

--- a/tests/dummy/app/templates/tooltip-with-type-class.hbs
+++ b/tests/dummy/app/templates/tooltip-with-type-class.hbs
@@ -1,0 +1,38 @@
+
+<ul class="examples">
+
+  <li>
+    {{test-component
+      tooltipContent='This is a tooltip with a type class "light"'
+      tooltipTypeClass='light'
+      data-test='with-type-class-light'
+    }}
+  </li>
+
+  <li>
+    {{test-component
+      tooltipContent='This is a tooltip with a type class "success"'
+      tooltipTypeClass='success'
+      data-test='with-type-class-success'
+    }}
+  </li>
+
+  <li>
+    {{test-component
+      tooltipContent='This is a tooltip with a type class "warning"'
+      tooltipTypeClass='warning'
+      data-test='with-type-class-warning'
+    }}
+  </li>
+
+  <li>
+    {{test-component
+      tooltipContent='This is a tooltip with a type class "error"'
+      tooltipTypeClass='error'
+      data-test='with-type-class-error'
+    }}
+  </li>
+
+</ul>
+
+{{code-snippet name='tooltip-with-type-class.hbs'}}

--- a/tests/helpers/async/assert-tooltip-properties.js
+++ b/tests/helpers/async/assert-tooltip-properties.js
@@ -42,8 +42,9 @@ export default Ember.Test.registerAsyncHelper('assertTooltipProperties',
 
     andThen(function() {
       const [ tooltip ] = Ember.$('.tooltip').toArray();
-      const indexOfEffectClass = tooltip.className.indexOf(expectedEffectClass);
-      const indexOfTypeClass = tooltip.className.indexOf(expectedTypeClass);
+      const classNames = tooltip.className.split(/\s+/);
+      const indexOfEffectClass = classNames.indexOf(expectedEffectClass);
+      const indexOfTypeClass = classNames.indexOf(expectedTypeClass);
 
       assert.ok(!!tooltip,
         'The tooltip should be added to the DOM after triggering the show event on the target element');


### PR DESCRIPTION
The vendor's css defines type classes like `.tooltip.light` and not `.tooltip-light`.

This also fixes the way the class names are asserted. Previously a simple string match was performed which won't fail for a given classname of `foo-bar` and an expected class name of `foo`.