### PR TITLE
Usage of `Ember.merge` is deprecated, use `Ember.assign` instead

### DIFF
--- a/app/initializers/ember-tooltips.js
+++ b/app/initializers/ember-tooltips.js
@@ -9,7 +9,7 @@ export function initialize() {
     addTo: ['Component'],
   };
   const overridingOptions = ENV.tooltips || {};
-  const options = Ember.merge(defaultOptions, overridingOptions);
+  const options = Ember.assign(defaultOptions, overridingOptions);
 
   /* TODO - Needs test coverage for addTo */
 


### PR DESCRIPTION
Getting out in front of this deprecation that will start throwing warnings in Ember 2.5.

_Huh, well that wasn't as easy as I thought.  I'll circle back once I get a little more time_