### PR TITLE
Fix deprecation warnings

### DIFF
--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -2,7 +2,8 @@
 import Ember from 'ember';
 
 const { Tooltip } = window;
-const { $, run, Handlebars: { SafeString } } = Ember;
+const { $, run } = Ember;
+const SafeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
 
 let tooltipIndex = 1;
 

--- a/app/initializers/ember-tooltips.js
+++ b/app/initializers/ember-tooltips.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import ENV from '../config/environment';
 import Tooltips from '../mixins/components/tooltips';
 
+const assign = Ember.assign || Ember.merge;
+
 /* This is in the app tree so we can access ENV */
 
 export function initialize() {
@@ -9,7 +11,7 @@ export function initialize() {
     addTo: ['Component'],
   };
   const overridingOptions = ENV.tooltips || {};
-  const options = Ember.merge(defaultOptions, overridingOptions);
+  const options = assign(defaultOptions, overridingOptions);
 
   /* TODO - Needs test coverage for addTo */
 

--- a/tests/dummy/app/controllers/tooltip-with-safestring.js
+++ b/tests/dummy/app/controllers/tooltip-with-safestring.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
- const SafeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
+const SafeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
 
 export default Ember.Controller.extend({
 

--- a/tests/dummy/app/controllers/tooltip-with-safestring.js
+++ b/tests/dummy/app/controllers/tooltip-with-safestring.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+ const safeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
+
 export default Ember.Controller.extend({
 
   actions: {
@@ -8,6 +10,6 @@ export default Ember.Controller.extend({
     },
   },
 
-  safeString: new Ember.Handlebars.SafeString('this is a test'),
+  safeString: new safeString('this is a test'),
 
 });

--- a/tests/dummy/app/controllers/tooltip-with-safestring.js
+++ b/tests/dummy/app/controllers/tooltip-with-safestring.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
- const safeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
+ const SafeString = Ember.String.htmlSafe || Ember.Handlebars.SafeString;
 
 export default Ember.Controller.extend({
 
@@ -10,6 +10,6 @@ export default Ember.Controller.extend({
     },
   },
 
-  safeString: new safeString('this is a test'),
+  safeString: new SafeString('this is a test'),
 
 });

--- a/tests/dummy/app/styles/components/_code.scss
+++ b/tests/dummy/app/styles/components/_code.scss
@@ -44,14 +44,14 @@ Block code
 
 pre {
   @include rem(padding, 2);
-  @extend %relative;
+  @extend %relative !optional;
 }
 
 pre code {
   @include rem(font-size, 1.5);
   background-color: transparent;
-  @extend %no-padding;
-  @extend %no-margin;
+  @extend %no-padding !optional;
+  @extend %no-margin !optional;
   color: $offwhite;
   line-height: 1.3;
   border: none;
@@ -66,12 +66,12 @@ pre code {
     text-transform: uppercase;
     @include rem(font-size, 1.2);
     @include rem(padding, 0.5, 1);
-    @extend %inline_block;
-    @extend %no-margin;
+    @extend %inline_block !optional;
+    @extend %no-margin !optional;
 
-    @extend %absolute;
-    @extend %top;
-    @extend %right;
+    @extend %absolute !optional;
+    @extend %top !optional;
+    @extend %right !optional;
 
     border: 1px solid rgba($black, 0.3);
     @include rem(border-bottom-left-radius, 0.3);

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -8,11 +8,13 @@ import './async/mouse-out';
 import './async/mouse-over';
 import './sync/inspect';
 
+const assign = Ember.assign || Ember.merge;
+
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Resolve the following deprecation warnings:
```
DEPRECATION: Usage of `Ember.merge` is deprecated, use `Ember.assign` instead. [deprecation id: ember-metal.merge] See http://emberjs.com/deprecations/v2.x/#toc_ember-merge for more details.
```

```
DEPRECATION: Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe [deprecation id: ember-htmlbars.ember-handlebars-safestring] See http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring for more details.
```