### PR TITLE
Fix aria-hidden bug

### DIFF
--- a/addon/utils/render-tooltip.js
+++ b/addon/utils/render-tooltip.js
@@ -57,7 +57,7 @@ export default function renderTooltip(domElement, options, context) {
       if (shouldShow) {
         tooltip._delayTimer = run.later(function() {
           tooltip.show();
-          $tooltip.attr('aria-hidden', true);
+          $tooltip.attr('aria-hidden', false);
           if (context) {
             context.set('tooltipVisibility', true);
           }
@@ -73,7 +73,7 @@ export default function renderTooltip(domElement, options, context) {
         }, delay);
       } else {
         tooltip.hide();
-        $tooltip.attr('aria-hidden', false);
+        $tooltip.attr('aria-hidden', true);
         if (context) {
           context.set('tooltipVisibility', false);
         }


### PR DESCRIPTION
Yesterday was **Global Accessibility Awareness Day**, as this was the ember-meetup theme, we looked at some much used ember-plugins and checked if the accessibility was correct. We found a small bug with the tooltip. It does not read out the related tooltip on with the screenreader. 
`aria-hidden` value was inverted (**`true`** on show and **`false`** on hidden) and didn't allow user using screen reader to actually read the tooltip content.