### PR TITLE
render tooltip immediately in testing mode

### DIFF
--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -70,6 +70,7 @@ export default EmberTetherComponent.extend({
   classPrefix: 'tooltip',
   classNames: ['tooltip'],
 
+  _didUpdateTimeoutLength: 1000, // 1000 ms or 0 ms, depending whether in test mode
   _hideTimer: null,
   _showTimer: null,
 
@@ -347,7 +348,7 @@ export default EmberTetherComponent.extend({
     run.later(() => {
       this.positionTether();
       this.sendAction('onTooltipRender', this);
-    }, 1000);
+    }, this.get('_didUpdateTimeoutLength'));
   },
 
   /*

--- a/app/components/tooltip-on-element.js
+++ b/app/components/tooltip-on-element.js
@@ -1,1 +1,6 @@
-export { default } from 'ember-tooltips/components/tooltip-on-element';
+import config from '../config/environment';
+import TooltipOnElement from 'ember-tooltips/components/tooltip-on-element';
+
+let _didUpdateTimeoutLength = config.environment === 'test' ? 0 : 1000;
+
+export default TooltipOnElement.extend({ _didUpdateTimeoutLength });

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "QUnit"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,0 +1,30 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+let originalTimeout;
+
+moduleForAcceptance('Acceptance | application', {
+
+  beforeEach: function() {
+    originalTimeout = QUnit.config.testTimeout;
+    QUnit.config.testTimeout = 2000;
+  },
+
+  afterEach: function() {
+    QUnit.config.testTimeout = originalTimeout;
+  }
+
+});
+
+/*
+This test makes sure that `didUpdate()` method in tooltip-on-element
+component renders the tooltip immediately in testing mode. If
+it is not rendering immediately in testing mode, the test will timeout.
+*/
+test('visiting /', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
When writing acceptance tests that involve ember-tooltips, the `didUpdate()` method in the `tooltip-on-element` method renders the tooltip 1000 ms later. However, if there are many tooltips on the page, this causes the acceptance test to take a very long time.

So in testing mode, this sets the default update time to 0ms.
