### PR TITLE
Fix aria-describedby syntax.

### DIFF
--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -292,7 +292,7 @@ export default EmberTetherComponent.extend({
     }
 
     $target.attr({
-      'aria-describedby': `#${this.get('elementId')}`,
+      'aria-describedby': `${this.get('elementId')}`,
       tabindex: $target.attr('tabindex') || this.get('tabindex'),
     });
 

--- a/tests/integration/components/tooltip-on-element-test.js
+++ b/tests/integration/components/tooltip-on-element-test.js
@@ -25,3 +25,22 @@ test('It renders', function(assert) {
     'Should create a tooltip element');
 
 });
+
+test('it has the proper aria-describedby tag', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`
+    <div>
+      Hover here!
+
+      {{#tooltip-on-element}}
+        Some info in a tooltip.
+      {{/tooltip-on-element}}
+    </div>
+  `);
+
+  let $tooltipTarget = this.$('.tooltip-target');
+  let describedBy = $tooltipTarget.attr('aria-describedby');
+  assert.equal(this.$(`#${describedBy}`).text().trim(), 'Some info in a tooltip.');
+  assert.equal(describedBy.indexOf('#'), '-1');
+});


### PR DESCRIPTION
Previously, we were creating elements like this:
```html
<div aria-describedby='#ember123'>
```
but the aria spec expects the attribute value to be an id without the `#` like this:
```html
<div aria-describedby='ember123'>
```

I discovered this when looking at the Chrome accessibility tools:

#### Before
![screen shot 2016-06-22 at 4 58 23 pm](https://cloud.githubusercontent.com/assets/630449/16287009/6688e446-389d-11e6-9bcb-cb4356419a7d.png)

#### After
![screen shot 2016-06-22 at 5 00 48 pm](https://cloud.githubusercontent.com/assets/630449/16287007/645362c8-389d-11e6-9db0-b2acdad4f59c.png)
