### PR TITLE
Add isDestroyed & isDestroying checks

### DIFF
--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
         console.warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }
 
-      if (!this.get('isDestroyed') && !this.get('isDestroying')) {
+      if (!this.isDestroying) {
         this.remove();
       }
     });

--- a/addon/components/tooltip-on-parent.js
+++ b/addon/components/tooltip-on-parent.js
@@ -25,7 +25,9 @@ export default Ember.Component.extend({
         console.warn('No renderTooltip method found on the parent view of the {{tooltip-on-parent}} component');
       }
 
-      this.remove();
+      if (!this.get('isDestroyed') && !this.get('isDestroying')) {
+        this.remove();
+      }
     });
   },
 

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -125,6 +125,10 @@ export default Ember.Mixin.create({
     const component = componentWasPassed ? maybeTooltipComponent : Ember.Object.create({});
     const renderContext = componentWasPassed ? component : this;
 
+    if (renderContext.get('isDestroying') || renderContext.get('isDestroyed')) {
+      return;
+    }
+
     let content = this.get('tooltipContent');
     let tooltip, tooltipOptions;
 

--- a/addon/mixins/components/tooltips.js
+++ b/addon/mixins/components/tooltips.js
@@ -125,7 +125,7 @@ export default Ember.Mixin.create({
     const component = componentWasPassed ? maybeTooltipComponent : Ember.Object.create({});
     const renderContext = componentWasPassed ? component : this;
 
-    if (renderContext.get('isDestroying') || renderContext.get('isDestroyed')) {
+    if (renderContext.isDestroying) {
       return;
     }
 


### PR DESCRIPTION
I have a scenario where component was in isDestroying state while ember-tooltips was trying to:
- render new tooltip content
- remove the tooltip-on-parent component

It happens when tooltips are inside of items of ember-power-select component.

This PR fixes the issue. I'm not exactly sure why is this happening but I guess these checks can't hurt anyone. Please correct me if I'm wrong :)

I don't know if this is happening in v1.0, can't upgrade yet (because of breaking changes).