### PR TITLE
Moves ember-beta to the list of `allow_failures`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:


### PR DESCRIPTION
Many builds are failing for this. While it is important to be aware of this failures and try to fix them in advance, I don't think they should necessarily be a blocker for CI and it might be better to have a separate issue to address these failures.