### PR TITLE
Correctly check for 'isDestroying'

### DIFF
--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -414,7 +414,7 @@ export default EmberTetherComponent.extend({
       }
 
       const _showTimer = run.later(this, () => {
-        if (!this.get('isDestroying')) {
+        if (!this.get('isDestroying') && !this.get('isDestroyed')) {
           this.set('tooltipIsVisible', true);
         }
       }, delay);

--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -414,7 +414,7 @@ export default EmberTetherComponent.extend({
       }
 
       const _showTimer = run.later(this, () => {
-        if (!this.get('destroying')) {
+        if (!this.get('isDestroying')) {
           this.set('tooltipIsVisible', true);
         }
       }, delay);


### PR DESCRIPTION
This fixes an issue with `Assertion Failed: calling set on destroyed object` when showing a tooltip on a component that is removed before the `delay` has passed