### PR TITLE
Fix: check for 'isDestoyed' when _showTimer runs

### DIFF
--- a/addon/components/tooltip-on-element.js
+++ b/addon/components/tooltip-on-element.js
@@ -414,7 +414,7 @@ export default EmberTetherComponent.extend({
       }
 
       const _showTimer = run.later(this, () => {
-        if (!this.get('destroying')) {
+        if (!this.get('destroying') && !this.get('isDestroyed')) {
           this.set('tooltipIsVisible', true);
         }
       }, delay);


### PR DESCRIPTION
This fixes an issue where an exception would be thrown about calling set on a destoyed component. This can happen if a component that has a tethered tooltip is destroyed before the tooltip has been shown