### PR TITLE
Disable tethering while tooltips are hidden

### DIFF
--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -360,8 +360,6 @@ export default EmberTetherComponent.extend({
   }),
 
   show() {
-    this.startTether();
-
     // this.positionTether() fixes the issues raised in
     // https://github.com/sir-dunxalot/ember-tooltips/issues/75
     this.positionTether();
@@ -393,6 +391,7 @@ export default EmberTetherComponent.extend({
 
       const _showTimer = run.later(this, () => {
         if (!this.get('destroying') && !this.get('isDestroyed')) {
+          this.startTether();
           this.set('isShown', true);
         }
       }, delay);
@@ -402,6 +401,7 @@ export default EmberTetherComponent.extend({
 
       /* If there is no delay, show the tooltop immediately */
 
+      this.startTether();
       this.set('isShown', true);
     }
 

--- a/addon/components/tooltip-and-popover.js
+++ b/addon/components/tooltip-and-popover.js
@@ -85,15 +85,20 @@ export default EmberTetherComponent.extend({
 
   /* Properties */
 
-  attributeBindings: ['aria-hidden', 'role', 'tabindex'],
+  attributeBindings: ['aria-hidden', 'role', 'tabindex', 'data-tether-enabled'],
   classNameBindings: ['effectClass'],
   classPrefix: 'ember-tooltip-or-popover',
-
+  
   _didUpdateTimeoutLength: 1000, // 1000 ms or 0 ms, depending whether in test mode
   _hideTimer: null,
   _showTimer: null,
+  _isTetherEnabled: true,
 
   /* CPs */
+
+  'data-tether-enabled': computed('_isTetherEnabled', function() {
+    return this.get('_isTetherEnabled') ? 'true' : 'false';
+  }),
 
   'aria-hidden': computed('isShown', function() {
     return this.get('isShown') ? 'false' : 'true';
@@ -240,6 +245,8 @@ export default EmberTetherComponent.extend({
 
     this.set('isShown', false);
     this.sendAction('onHide', this);
+
+    this.stopTether();
   },
 
   didInsertElement() {
@@ -298,6 +305,10 @@ export default EmberTetherComponent.extend({
     }
 
     this.set('offset', offset);
+
+    if (!this.get('isShown')) {
+      this.stopTether();
+    }
   },
 
   /*
@@ -327,6 +338,7 @@ export default EmberTetherComponent.extend({
     const isShown = this.get('isShown');
 
     if (isShown) {
+      this.startTether();
       const duration = cleanNumber(this.get('duration'));
 
       run.cancel(this.get('_hideTimer'));
@@ -342,10 +354,14 @@ export default EmberTetherComponent.extend({
 
         this.set('_hideTimer', hideTimer);
       }
+    } else {
+      this.stopTether();
     }
   }),
 
   show() {
+    this.startTether();
+
     // this.positionTether() fixes the issues raised in
     // https://github.com/sir-dunxalot/ember-tooltips/issues/75
     this.positionTether();
@@ -418,5 +434,21 @@ export default EmberTetherComponent.extend({
 
     this.sendAction('onDestroy', this);
   },
+
+  startTether() {
+    // can't depend on `_tether.enabled` because it's not an
+    // Ember property (so won't trigger cp update when changed)
+    this.set('_isTetherEnabled', true);
+    this.get('_tether').enable();
+  },
+
+  stopTether() {
+    run.schedule('afterRender', () => {
+      // can't depend on `_tether.enabled` because it's not an
+      // Ember property (so won't trigger cp update when changed)
+      this.set('_isTetherEnabled', false);
+      this.get('_tether').disable();
+    });
+  }
 
 });

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -8,18 +8,13 @@ export function assertShow(assert, context) {
 
 }
 
-export function assertHide(assert, context, options) {
-
-  // if the tooltip is shown after a delay, it should be hidden but
-  // tethering should still be enabled
-  let tetherEnabled = options && options.tetherEnabled;
-  let tetherAttrValue = tetherEnabled ? 'true' : 'false';
+export function assertHide(assert, context) {
 
   assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'true',
     'Should hide tooltip');
 
-  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), tetherAttrValue,
-    `Should ${tetherEnabled ? 'enable' : 'disable'} tether`);
+  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), 'false',
+    'Should disable tether');
 
 }
 

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -12,6 +12,20 @@ export function assertHide(assert, context) {
 
 }
 
+export function assertTetherEnabled(assert, context) {
+
+  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), 'true',
+    'Should enable tether');
+
+}
+
+export function assertTetherDisabled(assert, context) {
+
+  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), 'false',
+    'Should disable tether');
+
+}
+
 
 export function assertPopoverShow(assert, context) {
 

--- a/tests/helpers/sync/assert-visibility.js
+++ b/tests/helpers/sync/assert-visibility.js
@@ -2,35 +2,34 @@ export function assertShow(assert, context) {
 
   assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'false',
     'Should show tooltip');
-
-}
-
-export function assertHide(assert, context) {
-
-  assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'true',
-    'Should hide tooltip');
-
-}
-
-export function assertTetherEnabled(assert, context) {
-
+  
   assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), 'true',
     'Should enable tether');
 
 }
 
-export function assertTetherDisabled(assert, context) {
+export function assertHide(assert, context, options) {
 
-  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), 'false',
-    'Should disable tether');
+  // if the tooltip is shown after a delay, it should be hidden but
+  // tethering should still be enabled
+  let tetherEnabled = options && options.tetherEnabled;
+  let tetherAttrValue = tetherEnabled ? 'true' : 'false';
+
+  assert.equal(context.$().find('.ember-tooltip').attr('aria-hidden'), 'true',
+    'Should hide tooltip');
+
+  assert.equal(context.$().find('.ember-tooltip').attr('data-tether-enabled'), tetherAttrValue,
+    `Should ${tetherEnabled ? 'enable' : 'disable'} tether`);
 
 }
-
 
 export function assertPopoverShow(assert, context) {
 
   assert.equal(context.$().find('.ember-popover').attr('aria-hidden'), 'false',
     'Should show popover');
+
+  assert.equal(context.$().find('.ember-popover').attr('data-tether-enabled'), 'true',
+    'Should enable tether');
 
 }
 
@@ -38,5 +37,8 @@ export function assertPopoverHide(assert, context) {
 
   assert.equal(context.$().find('.ember-popover').attr('aria-hidden'), 'true',
     'Should hide popover');
+
+  assert.equal(context.$().find('.ember-popover').attr('data-tether-enabled'), 'false',
+    'Should disable tether');
 
 }

--- a/tests/integration/components/delay-test.js
+++ b/tests/integration/components/delay-test.js
@@ -27,7 +27,7 @@ test('It animates with delay passed as a number', function(assert) {
   run.later(() => {
     // tether should be enabled, because the tooltip must be positioned
     // before it is shown
-    assertHide(assert, this, { tetherEnabled: true });
+    assertHide(assert, this);
   }, 290);
 
   run.later(() => {
@@ -66,7 +66,7 @@ test('It animates with delay passed as a string', function(assert) {
   run.later(() => {
     // tether should be enabled, because the tooltip must be positioned
     // before it is shown
-    assertHide(assert, this, { tetherEnabled: true });
+    assertHide(assert, this);
   }, 290);
 
   run.later(() => {

--- a/tests/integration/components/delay-test.js
+++ b/tests/integration/components/delay-test.js
@@ -12,7 +12,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | delay', {
 test('It animates with delay passed as a number', function(assert) {
   const done = assert.async();
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-element delay=300}}`);
 
@@ -25,7 +25,9 @@ test('It animates with delay passed as a number', function(assert) {
   /* Check the tooltip is shown after the correct delay */
 
   run.later(() => {
-    assertHide(assert, this);
+    // tether should be enabled, because the tooltip must be positioned
+    // before it is shown
+    assertHide(assert, this, { tetherEnabled: true });
   }, 290);
 
   run.later(() => {
@@ -49,7 +51,7 @@ test('It animates with delay passed as a number', function(assert) {
 test('It animates with delay passed as a string', function(assert) {
   const done = assert.async();
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-element delay='300'}}`);
 
@@ -62,7 +64,9 @@ test('It animates with delay passed as a string', function(assert) {
   /* Check the tooltip is shwon after the correct delay */
 
   run.later(() => {
-    assertHide(assert, this);
+    // tether should be enabled, because the tooltip must be positioned
+    // before it is shown
+    assertHide(assert, this, { tetherEnabled: true });
   }, 290);
 
   run.later(() => {

--- a/tests/integration/components/duration-test.js
+++ b/tests/integration/components/duration-test.js
@@ -12,7 +12,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | duration', {
 test('It hides after the given duration', function(assert) {
   const done = assert.async();
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element duration=300}}`);
 
@@ -35,7 +35,7 @@ test('It hides after the given duration', function(assert) {
 
 test('It hides before the given duration, if requested', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element duration=300}}`);
 
@@ -58,7 +58,7 @@ test('It hides before the given duration, if requested', function(assert) {
 test('It uses duration after the first show', function(assert) {
   const done = assert.async();
 
-  assert.expect(5);
+  assert.expect(10);
 
   this.render(hbs`{{tooltip-on-element duration=300}}`);
 

--- a/tests/integration/components/event-test.js
+++ b/tests/integration/components/event-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | event', {
 
 test('It toggles with hover', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element}}`);
 
@@ -33,7 +33,7 @@ test('It toggles with hover', function(assert) {
 
 test('It toggles with click', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element event='click'}}`);
 
@@ -55,7 +55,7 @@ test('It toggles with click', function(assert) {
 
 test('It toggles with focus', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`
     <div id="target">
@@ -83,7 +83,7 @@ test('It toggles with focus', function(assert) {
 
 test('It does not show with none', function(assert) {
 
-  assert.expect(4);
+  assert.expect(8);
 
   this.render(hbs`{{tooltip-on-element event='none'}}`);
 

--- a/tests/integration/components/hide-on-test.js
+++ b/tests/integration/components/hide-on-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | hideOn', {
 
 test('It hides with hideOn', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element hideOn='click'}}`);
 

--- a/tests/integration/components/popover/api-test.js
+++ b/tests/integration/components/popover/api-test.js
@@ -35,7 +35,7 @@ test('Popover: click target, click hideAction', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -72,7 +72,7 @@ test('Popover: click target, click hideAction, click target', function(assert) {
 
   assertPopoverShow(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -116,6 +116,6 @@ test('Popover: click target, click popover, click hideAction, click target', fun
 
   assertPopoverShow(assert, this);
 
-  assert.expect(5);
+  assert.expect(10);
 
 });

--- a/tests/integration/components/popover/click-test.js
+++ b/tests/integration/components/popover/click-test.js
@@ -31,7 +31,7 @@ test('Popover: click target, click target', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -64,7 +64,7 @@ test('Popover: click target, click popover, click target', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -96,7 +96,7 @@ test('Popover: click target, click elsewhere', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -135,6 +135,6 @@ test('Popover: click target, click popover, click elsewhere', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });

--- a/tests/integration/components/popover/focus-test.js
+++ b/tests/integration/components/popover/focus-test.js
@@ -44,7 +44,7 @@ test('Popover: target focus, popover focus, popover blur', function(assert) {
 		done();
 	}, 100);
 
-	assert.expect(4);
+	assert.expect(8);
 
 });
 
@@ -92,7 +92,7 @@ test('Popover: target focus, targetInterior focus, popover focus, popover blur',
 		done();
 	}, 100);
 
-	assert.expect(5);
+	assert.expect(10);
 
 });
 
@@ -140,6 +140,6 @@ test('Popover: target focus, popover focus, popoverInterior focus, popover blur'
 		done();
 	}, 100);
 
-	assert.expect(5);
+	assert.expect(10);
 
 });

--- a/tests/integration/components/popover/hover-test.js
+++ b/tests/integration/components/popover/hover-test.js
@@ -35,7 +35,7 @@ test('Popover: hover target, hover elsewhere', function(assert) {
     done();
   }, 300);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });
 
@@ -69,7 +69,7 @@ test('Popover: hover target, hover popover (too slow)', function(assert) {
     done();
   }, 500);
 
-  assert.expect(3);
+  assert.expect(6);
 
 });
 
@@ -130,6 +130,6 @@ test('Popover: hover target, hover inbetween, hover popover, hover elsewhere', f
     done();
   }, 1000);
 
-  assert.expect(6);
+  assert.expect(12);
 
 });

--- a/tests/integration/components/popover/none-test.js
+++ b/tests/integration/components/popover/none-test.js
@@ -42,6 +42,6 @@ test('Popover: never shows with none', function(assert) {
 
   assertPopoverHide(assert, this);
 
-  assert.expect(4);
+  assert.expect(8);
 
 });

--- a/tests/integration/components/show-on-test.js
+++ b/tests/integration/components/show-on-test.js
@@ -11,7 +11,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | showOn', {
 
 test('It shows with showOn', function(assert) {
 
-  assert.expect(3);
+  assert.expect(6);
 
   this.render(hbs`{{tooltip-on-element showOn='click'}}`);
 

--- a/tests/integration/components/tooltip-is-visible-test.js
+++ b/tests/integration/components/tooltip-is-visible-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
-import { assertHide, assertShow, assertTetherEnabled, assertTetherDisabled } from '../../helpers/sync/assert-visibility';
+import { assertHide, assertShow } from '../../helpers/sync/assert-visibility';
 import hbs from 'htmlbars-inline-precompile';
 
 const { run } = Ember;
@@ -18,14 +18,12 @@ test('It toggles with isShown', function(assert) {
   this.render(hbs`{{tooltip-on-element isShown=showTooltip}}`);
 
   assertShow(assert, this);
-  assertTetherEnabled(assert, this);
-
+  
   run(() => {
     this.set('showTooltip', false);
   });
 
   assertHide(assert, this);
-  assertTetherDisabled(assert, this);
 
 });
 
@@ -40,13 +38,11 @@ test('It toggles with tooltipIsVisible', function(assert) {
   this.render(hbs`{{tooltip-on-element tooltipIsVisible=showTooltip}}`);
 
   assertShow(assert, this);
-  assertTetherEnabled(assert, this);
 
   run(() => {
     this.set('showTooltip', false);
   });
 
   assertHide(assert, this);
-  assertTetherDisabled(assert, this);
 
 });

--- a/tests/integration/components/tooltip-is-visible-test.js
+++ b/tests/integration/components/tooltip-is-visible-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
-import { assertHide, assertShow } from '../../helpers/sync/assert-visibility';
+import { assertHide, assertShow, assertTetherEnabled, assertTetherDisabled } from '../../helpers/sync/assert-visibility';
 import hbs from 'htmlbars-inline-precompile';
 
 const { run } = Ember;
@@ -11,19 +11,21 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | isShown', {
 
 test('It toggles with isShown', function(assert) {
 
-  assert.expect(2);
+  assert.expect(4);
 
   this.set('showTooltip', true);
 
   this.render(hbs`{{tooltip-on-element isShown=showTooltip}}`);
 
   assertShow(assert, this);
+  assertTetherEnabled(assert, this);
 
   run(() => {
     this.set('showTooltip', false);
   });
 
   assertHide(assert, this);
+  assertTetherDisabled(assert, this);
 
 });
 
@@ -31,18 +33,20 @@ test('It toggles with tooltipIsVisible', function(assert) {
 	// tooltipIsVisible is deprecated in favor of isShown
 	// tooltipIsVisible will be supported until v3.0.0
 
-  assert.expect(2);
+  assert.expect(4);
 
   this.set('showTooltip', true);
 
   this.render(hbs`{{tooltip-on-element tooltipIsVisible=showTooltip}}`);
 
   assertShow(assert, this);
+  assertTetherEnabled(assert, this);
 
   run(() => {
     this.set('showTooltip', false);
   });
 
   assertHide(assert, this);
+  assertTetherDisabled(assert, this);
 
 });


### PR DESCRIPTION
This was causing performance issues on pages with many tooltips, because each repositioning triggered a forced reflow (which is expensive in most browsers, but especially in IE).