### PR TITLE
Proper text break instead of overflowing

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -31,6 +31,7 @@
   color: #fff;
   background: #3a3c47;
   text-shadow: -1px -1px 0 rgba(0,0,0,0.2);
+  white-space: initial;
 
   &:after {
     content: '';


### PR DESCRIPTION
Fixes #105.

Picture says it all:

Before`.ember-tooltip { white-space: initial; }` addition (in my project, latest Chrome):

![image](https://cloud.githubusercontent.com/assets/273660/19659875/f2295e58-9a2d-11e6-9dae-14b2f4a8b446.png)

After adding this piece of CSS:

![image](https://cloud.githubusercontent.com/assets/273660/19659892/02d9cf4e-9a2e-11e6-9c5d-c595307e3ac9.png)


