### PR TITLE
Text property

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The easiest way to add a tooltip to any component is with the `{{tooltip-on-comp
 {{#my-component}}
   Hover for more info
 
-  {{tooltip-on-component 'Here is more info!'}}
+  {{tooltip-on-component text='Here is more info!'}}
 {{/my-component}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ The easiest way to add a tooltip to any component is with the `{{tooltip-on-comp
 {{#my-component}}
   Hover for more info
 
+  {{tooltip-on-component 'Here is more info!'}}
+{{/my-component}}
+```
+
+Or in block form:
+
+```hbs
+{{#my-component}}
+  Hover for more info
+
   {{#tooltip-on-component}}
     Here is the info in a tooltip!
   {{/tooltip-on-component}}
@@ -71,6 +81,16 @@ Documentation for supported options is located [here](#options).
 If you want to add a tooltip to an element that is not an Ember component, you can do so with `{{tooltip-on-element}}`.
 
 By default, the tooltip will attach itself to its parent element:
+
+```hbs
+<div>
+  Hover for more info
+
+  {{tooltip-on-element text='Here is more info!'}}
+</div>
+```
+
+Or in block form:
 
 ```hbs
 <div>

--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -37,6 +37,7 @@ const PASSABLE_PROPERTIES = [
 	'tooltipIsVisible',
 	'hideDelay',
 	'target',
+	'text',
 
 	// non-publicized attributes
 	'updateFor',

--- a/addon/templates/components/lazy-render-wrapper.hbs
+++ b/addon/templates/components/lazy-render-wrapper.hbs
@@ -4,12 +4,12 @@
 		class=class
 		id=id
 	}}
-    {{#if text}}
-      {{text}}
-    {{else}}
+    {{#if hasBlock}}
       {{yield (hash
         hide=(action "hide")
       )}}
+    {{else}}
+      {{text}}
     {{/if}}
 	{{/component}}
 {{/if}}

--- a/addon/templates/components/lazy-render-wrapper.hbs
+++ b/addon/templates/components/lazy-render-wrapper.hbs
@@ -4,9 +4,13 @@
 		class=class
 		id=id
 	}}
-		{{yield (hash
-			hide=(action "hide")
-		)}}
+    {{#if text}}
+      {{text}}
+    {{else}}
+      {{yield (hash
+        hide=(action "hide")
+      )}}
+    {{/if}}
 	{{/component}}
 {{/if}}
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -210,7 +210,7 @@
 <div class="page-content">
   <h3 id="inline">Using in inline form</h3>
 
-{{!-- BEGIN-SNIPPET async-content --}}
+{{!-- BEGIN-SNIPPET inline-content --}}
 {{#some-component}}
   Tooltip has async content
 
@@ -218,6 +218,6 @@
 {{/some-component}}
 {{!-- END-SNIPPET --}}
 
-  {{code-snippet name='async-content.hbs'}}
+  {{code-snippet name='inline-content.hbs'}}
 
 </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -52,6 +52,7 @@
     <li><a href="#styling">Using custom styling</a></li>
     <li><a href="#async">Using async content</a></li>
     <li><a href="#popover">Using a popover instead of a tooltip</a></li>
+    <li><a href="#inline">Using in inline form</a></li>
   </ul>
 </div>
 
@@ -203,5 +204,20 @@
 {{!-- END-SNIPPET --}}
 
   {{code-snippet name='popover.hbs'}}
+
+</div>
+
+<div class="page-content">
+  <h3 id="inline">Using in inline form</h3>
+
+{{!-- BEGIN-SNIPPET async-content --}}
+{{#some-component}}
+  Tooltip has async content
+
+  {{tooltip-on-component text='More info here'}}
+{{/some-component}}
+{{!-- END-SNIPPET --}}
+
+  {{code-snippet name='async-content.hbs'}}
 
 </div>

--- a/tests/integration/components/text-test.js
+++ b/tests/integration/components/text-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('tooltip-on-element', 'Integration | Component | text', {
+  integration: true
+});
+
+test('It renders', function(assert) {
+
+  this.render(hbs`
+    {{tooltip-on-element text='Here is more info'}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'Here is more info',
+    'Should render with content equal to the text property');
+
+  assert.ok(this.$().find('.ember-tooltip').length,
+    'Should create a tooltip element');
+
+});

--- a/tests/integration/components/text-test.js
+++ b/tests/integration/components/text-test.js
@@ -1,11 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('tooltip-on-element', 'Integration | Component | text', {
+moduleForComponent('tooltip-on-element', 'Integration | Component | inline', {
   integration: true
 });
 
-test('It renders', function(assert) {
+test('tooltip-on-element renders with text param', function(assert) {
 
   this.render(hbs`
     {{tooltip-on-element text='Here is more info'}}


### PR DESCRIPTION
This PR adds a `text` property to tooltips and popovers. This lets the dev use tooltips and popovers in inline form. For example:

```hbs
{{#my-component}}
  Hover for more info

  {{tooltip-on-component text='Here is more info!'}}
{{/my-component}}
```

Instead of:

```hbs
{{#my-component}}
  Hover for more info

  {{#tooltip-on-component}}
    Here is more info!
  {{/tooltip-on-component}}
{{/my-component}}
```