### PR TITLE
Remove some-component from addon files

### DIFF
--- a/addon/components/some-component.js
+++ b/addon/components/some-component.js
@@ -1,6 +1,0 @@
-import Ember from 'ember';
-
-// empty component used for `-on-component` tests
-export default Ember.Component.extend({
-	classNames: 'some-component',
-});

--- a/app/components/some-component.js
+++ b/app/components/some-component.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-tooltips/components/some-component';


### PR DESCRIPTION
This PR removes the `some-component` component from addon files. We only need it in tests and it already exists for tests [here](https://github.com/sir-dunxalot/ember-tooltips/blob/547ec11ccb0725cbfe92234445cd8f128e43135d/tests/dummy/app/components/some-component.js). If we don't remove these files, every consuming app will have a `some-component` component added to it by this addon.