### PR TITLE
BUGFIX checkif component is destroyed before trying to set properties…

### DIFF
--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -482,10 +482,13 @@ export default EmberTetherComponent.extend({
 
   stopTether() {
     run.schedule('afterRender', () => {
-      // can't depend on `_tether.enabled` because it's not an
-      // Ember property (so won't trigger cp update when changed)
-      this.set('_isTetherEnabled', false);
-      this.get('_tether').disable();
+      if (!this.isDestroyed && !this.isDestroying) {
+
+        // can't depend on `_tether.enabled` because it's not an
+        // Ember property (so won't trigger cp update when changed)
+        this.set('_isTetherEnabled', false);
+        this.get('_tether').disable();
+      }
     });
   },
 


### PR DESCRIPTION
… on it

This is something that came up for me when I upgraded an app to Ember 2.10 with the Glimmer2 rendering engine. It is possible in some scenarios in my component to remove a tooltip so quickly that this `stopTether` runs after it is already destroyed. A simple `isDestroyed` check avoids the bug.

Thank you for your consideration...