### PR TITLE
add LTS 2.4 and 2.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,15 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bower's cache
 
 env:
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -22,7 +26,9 @@ matrix:
 before_install:
   - npm config set spin false
   - npm install -g bower
+  - bower --version
   - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install
@@ -30,5 +36,5 @@ install:
 
 script:
   # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  # to the addon's original dependency state, skipping "cleanup".
+  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ cache:
     - $HOME/.cache # includes bower's cache
 
 env:
-  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,12 +2,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
       name: 'ember-1.13',
       bower: {
         dependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -19,6 +19,28 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {


### PR DESCRIPTION
* adds LTS support for version 2.4 and 2.8
* removes the `default` scenario.
  * the `default` scenario was the same as the `ember-release` scenario because our ember-version is ^2.6.0, which currently resolves to 2.10.1

Thanks for the inspiration @knownasilya https://github.com/sir-dunxalot/ember-tooltips/pull/120