### PR TITLE
passing classNames

### DIFF
--- a/addon/templates/components/lazy-render-wrapper.hbs
+++ b/addon/templates/components/lazy-render-wrapper.hbs
@@ -4,6 +4,7 @@
 		class=class
 		id=id
 		_shouldShowOnRender=_shouldShowOnRender
+    classNames=classNames
 	}}
     {{#if hasBlock}}
       {{yield (hash

--- a/tests/integration/components/pass-through-test.js
+++ b/tests/integration/components/pass-through-test.js
@@ -17,6 +17,7 @@ test('tooltip-on-element pass through attributes test', function(assert) {
   		id="some-id"
 			class='foo'
 			classNameBindings='bar:bar-truthy:bar-falsy baz:baz-truthy:baz-falsy'
+      classNames="foobar"
 			role='foo'
 			tabindex='2'
   	}}
@@ -35,6 +36,8 @@ test('tooltip-on-element pass through attributes test', function(assert) {
   assert.ok($tooltip.hasClass('bar-falsy'));
 
   assert.ok($tooltip.hasClass('baz-truthy'));
+
+  assert.ok($tooltip.hasClass('foobar'));
 
   assert.equal($tooltip.attr('role'), 'foo');
 


### PR DESCRIPTION
Fixes https://github.com/sir-dunxalot/ember-tooltips/issues/112

Added pass-through coverage for `classNames`