### PR TITLE
add `white-space: normal;` because IE doesnt support `initial`

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -31,7 +31,7 @@
   color: #fff;
   background: #3a3c47;
   text-shadow: -1px -1px 0 rgba(0,0,0,0.2);
-  white-space: normal;
+  white-space: normal; // IE doesnt support initial so fall back to normal
   white-space: initial;
 
   &:after {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -31,6 +31,7 @@
   color: #fff;
   background: #3a3c47;
   text-shadow: -1px -1px 0 rgba(0,0,0,0.2);
+  white-space: normal;
   white-space: initial;
 
   &:after {


### PR DESCRIPTION
This fixes #126.
IE doest support `white-space: initial;`, so it will fall back to `inherit`.