### PR TITLE
Position test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ This addon exposes testing helpers which can be used inside of the consuming app
 * `assertTooltipNotVisible(assert)`: asserts if the tooltip is not visible. It checks two attributes on the $tooltip: aria-hidden and data-tether-enabled.
 * `assertTooltipRendered(assert)`: asserts if the tooltip has been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element. A tooltip can be rendered but not visible.
 * `assertTooltipNotRendered(assert)`: asserts if the tooltip has not been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element.
+* `assertTooltipSide(assert, { side: 'right' }): asserts that the tooltip is shown on the correct side of the target. Additional options that can be passed are `selector` and `targetSelector`.
 * `triggerTooltipTargetEvent($targetElement, eventName)`: triggers an event on the passed element. The event will be triggered within an Ember.run so that the tooltip's asynchronicity is accounted for. eventName can be mouseenter, mouseleave, click, focus, focusin, and blur.
 
 Each test helper also accepts an `options` object as a final parameter. If a `selector` property is provided the assertions and actions will be run against the single element found from that selector.

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -126,16 +126,16 @@ export function assertTooltipSide(assert, options = {}) {
   const tooltipPosition = $tooltip[0].getBoundingClientRect();
 
   if (expectedSide === 'top') {
-    assert.ok(targetPosition.top > tooltipPosition.top,
+    assert.ok(targetPosition.top > tooltipPosition.bottom,
       'Tooltip should be above the target');
   } else if (expectedSide === 'right') {
-    assert.ok(targetPosition.left < tooltipPosition.left,
+    assert.ok(targetPosition.right < tooltipPosition.left,
       'Tooltip should be right of the target');
   } else if (expectedSide === 'bottom') {
-    assert.ok(targetPosition.top < tooltipPosition.top,
+    assert.ok(targetPosition.bottom < tooltipPosition.top,
       'Tooltip should be below the target');
   } else if (expectedSide === 'left') {
-    assert.ok(targetPosition.left > tooltipPosition.left,
+    assert.ok(targetPosition.left > tooltipPosition.right,
       'Tooltip should be left of the target');
   }
 }

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -100,7 +100,7 @@ export function assertTooltipVisible(assert, options={}) {
         isTooltipTetherEnabled -> ${isTooltipTetherEnabled}`);
 }
 
-export function assertTooltipPosition(assert, options = {}) {
+export function assertTooltipSide(assert, options = {}) {
   const expectedSide = options.side || 'top';
   const $target = getTooltipTargetFromBody(options.targetSelector);
   const targetPosition = $target.position();

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const tooltipOrPopoverSelector = '.ember-tooltip, .ember-popover';
+const tooltipOrPopoverTargetSelector = '.ember-tooltip-or-popover-target';
 
 const getTooltipFromBody = function(selector=tooltipOrPopoverSelector) {
   // we have to .find() tooltips from $body because sometimes
@@ -13,10 +14,21 @@ const getTooltipFromBody = function(selector=tooltipOrPopoverSelector) {
   if (!$tooltip.hasClass('ember-tooltip') && !$tooltip.hasClass('ember-popover')) {
     throw Error(`getTooltipFromBody(): returned an element that is not a tooltip`);
   } else if ($tooltip.length > 1) {
-    throw Error('getTooltipFromBody(): Multiple tooltips were found. Please provide an {option.selector = ".specific-tooltip-class"}')
+    throw Error('getTooltipFromBody(): Multiple tooltips were found. Please provide an {option.selector = ".specific-tooltip-class"}');
   }
 
   return $tooltip;
+}
+
+const getTooltipTargetFromBody = function(selector = tooltipOrPopoverTargetSelector) {
+  const $body = Ember.$(document.body);
+  const $tooltipTarget = $body.find(selector) ;
+
+  if ($tooltipTarget.length > 1) {
+    throw Error('getTooltipTargetFromBody(): Multiple tooltip targets were found. Please provide an {option.targetSelector = ".specific-tooltip-target-class"}');
+  }
+
+  return $tooltipTarget;
 }
 
 export function triggerTooltipTargetEvent($element, type, options={}) {
@@ -86,4 +98,26 @@ export function assertTooltipVisible(assert, options={}) {
       `assertTooltipVisible(): the ember-tooltip should be visible and the tether should be enabled:
         isTooltipVisible -> ${isTooltipVisible} ;
         isTooltipTetherEnabled -> ${isTooltipTetherEnabled}`);
+}
+
+export function assertTooltipPosition(assert, options = {}) {
+  const expectedSide = options.side || 'top';
+  const $target = getTooltipTargetFromBody(options.targetSelector);
+  const targetPosition = $target.position();
+  const $tooltip = getTooltipFromBody(options.selector);
+  const tooltipPosition = $tooltip.position();
+
+  if (expectedSide === 'top') {
+    assert.ok(targetPosition.top > tooltipPosition.top,
+      'Tooltip should be above the target');
+  } else if (expectedSide === 'right') {
+    assert.ok(targetPosition.left < tooltipPosition.left,
+      'Tooltip should be right of the target');
+  } else if (expectedSide === 'bottom') {
+    assert.ok(targetPosition.top < tooltipPosition.top,
+      'Tooltip should be below the target');
+  } else if (expectedSide === 'left') {
+    assert.ok(targetPosition.left > tooltipPosition.left,
+      'Tooltip should be left of the target');
+  }
 }

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { $, run } = Ember;
+
 const tooltipOrPopoverSelector = '.ember-tooltip, .ember-popover';
 const tooltipOrPopoverTargetSelector = '.ember-tooltip-or-popover-target';
 
@@ -8,7 +10,7 @@ const getTooltipFromBody = function(selector=tooltipOrPopoverSelector) {
   // tooltips and popovers are rendered as children of <body>
   // instead of children of the $targetElement
 
-  const $body = Ember.$(document.body);
+  const $body = $(document.body);
   const $tooltip = $body.find(selector) ;
 
   if (!$tooltip.hasClass('ember-tooltip') && !$tooltip.hasClass('ember-popover')) {
@@ -21,7 +23,7 @@ const getTooltipFromBody = function(selector=tooltipOrPopoverSelector) {
 }
 
 const getTooltipTargetFromBody = function(selector = tooltipOrPopoverTargetSelector) {
-  const $body = Ember.$(document.body);
+  const $body = $(document.body);
   const $tooltipTarget = $body.find(selector) ;
 
   if ($tooltipTarget.length > 1) {
@@ -47,7 +49,7 @@ export function triggerTooltipTargetEvent($element, type, options={}) {
 
   // we need to need to wrap any code with asynchronous side-effects in a run
   // $tooltipTarget.trigger('someEvent') has asynchronous side-effects
-  Ember.run(() => {
+  run(() => {
     // if the $tooltip is hidden then the user can't interact with it
     if ($element.attr('aria-hidden') === 'true') {
       return;
@@ -66,7 +68,7 @@ export function triggerTooltipTargetEvent($element, type, options={}) {
 }
 
 export function assertTooltipNotRendered(assert, options={}) {
-  const $body = Ember.$(document.body);
+  const $body = $(document.body);
   const $tooltip = $body.find(options.selector || tooltipOrPopoverSelector);
 
   assert.equal($tooltip.length, 0, 'assertTooltipNotRendered(): the ember-tooltip should not be rendered');
@@ -101,11 +103,27 @@ export function assertTooltipVisible(assert, options={}) {
 }
 
 export function assertTooltipSide(assert, options = {}) {
+  const { side } = options;
+
+  const sideIsValid = (
+    side === 'top' ||
+    side === 'right' ||
+    side === 'bottom' ||
+    side === 'left'
+  );
+
+  /* We make sure the side being tested is valid. We
+  use Ember.assert because assert is passed in from QUnit */
+
+  if (!sideIsValid) {
+    Ember.assert(`You must pass side like assertTooltipSide(assert, { side: 'top' }); Valid options for side are top, right, bottom, and left.`);
+  }
+
   const expectedSide = options.side || 'top';
   const $target = getTooltipTargetFromBody(options.targetSelector);
-  const targetPosition = $target.position();
+  const targetPosition = $target[0].getBoundingClientRect();
   const $tooltip = getTooltipFromBody(options.selector);
-  const tooltipPosition = $tooltip.position();
+  const tooltipPosition = $tooltip[0].getBoundingClientRect();
 
   if (expectedSide === 'top') {
     assert.ok(targetPosition.top > tooltipPosition.top,

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -73,6 +73,6 @@ test('tooltip-on-element shows with showOn left', function(assert) {
 //     {{/tooltip-on-element}}
 //   `);
 
-//    assertPosition(assert, this, 'right');
+//    assertTooltipSide(assert, { side: 'right' });
 
 // });

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { assertTooltipSide } from '../../tests/helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | side and keepInWindow', {
   integration: true
@@ -14,7 +15,7 @@ test('tooltip-on-element shows', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='top' keepInWindow=false}}`);
 
-  assertPosition(assert, this, 'top');
+  assertTooltipSide(assert, 'top');
 
 });
 
@@ -24,7 +25,7 @@ test('tooltip-on-element shows with showOn right', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='right' keepInWindow=false}}`);
 
-  assertPosition(assert, this, 'right');
+  assertTooltipSide(assert, 'right');
 
 });
 
@@ -34,7 +35,7 @@ test('tooltip-on-element shows with showOn bottom', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='bottom' keepInWindow=false}}`);
 
-  assertPosition(assert, this, 'bottom');
+  assertTooltipSide(assert, 'bottom');
 
 });
 
@@ -44,7 +45,7 @@ test('tooltip-on-element shows with showOn left', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='left' keepInWindow=false}}`);
 
-  assertPosition(assert, this, 'left');
+  assertTooltipSide(assert, 'left');
 
 });
 

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -1,26 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-function assertPosition(assert, context, expectedSide) {
-  const $this = context.$();
-  const targetPosition = $this.position();
-  const tooltipPosition = $this.find('.ember-tooltip').position();
-
-  if (expectedSide === 'top') {
-    assert.ok(targetPosition.top > tooltipPosition.top,
-      'Tooltip should be above the target');
-  } else if (expectedSide === 'right') {
-    assert.ok(targetPosition.left < tooltipPosition.left,
-      'Tooltip should be right of the target');
-  } else if (expectedSide === 'bottom') {
-    assert.ok(targetPosition.top < tooltipPosition.top,
-      'Tooltip should be below the target');
-  } else if (expectedSide === 'left') {
-    assert.ok(targetPosition.left > tooltipPosition.left,
-      'Tooltip should be left of the target');
-  }
-}
-
 moduleForComponent('tooltip-on-element', 'Integration | Option | side and keepInWindow', {
   integration: true
 });

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipSide } from '../../tests/helpers/ember-tooltips';
+import { assertTooltipSide } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | side and keepInWindow', {
   integration: true

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -9,13 +9,23 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | side and keepIn
 /* Test the positions without forcing the tooltip
 to stay in the window. */
 
-test('tooltip-on-element shows', function(assert) {
+test('tooltip-on-element shows on the top by default', function(assert) {
+
+  assert.expect(1);
+
+  this.render(hbs`{{tooltip-on-element keepInWindow=false}}`);
+
+  assertTooltipSide(assert, { side: 'top' });
+
+});
+
+test('tooltip-on-element shows on the top', function(assert) {
 
   assert.expect(1);
 
   this.render(hbs`{{tooltip-on-element side='top' keepInWindow=false}}`);
 
-  assertTooltipSide(assert, 'top');
+  assertTooltipSide(assert, { side: 'top' });
 
 });
 
@@ -25,7 +35,7 @@ test('tooltip-on-element shows with showOn right', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='right' keepInWindow=false}}`);
 
-  assertTooltipSide(assert, 'right');
+  assertTooltipSide(assert, { side: 'right' });
 
 });
 
@@ -35,7 +45,7 @@ test('tooltip-on-element shows with showOn bottom', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='bottom' keepInWindow=false}}`);
 
-  assertTooltipSide(assert, 'bottom');
+  assertTooltipSide(assert, { side: 'bottom' });
 
 });
 
@@ -45,7 +55,7 @@ test('tooltip-on-element shows with showOn left', function(assert) {
 
   this.render(hbs`{{tooltip-on-element side='left' keepInWindow=false}}`);
 
-  assertTooltipSide(assert, 'left');
+  assertTooltipSide(assert, { side: 'left' });
 
 });
 


### PR DESCRIPTION
This PR adds a `assertTooltipPosition()` public test helper:

```js
assertTooltipPosition(assert, { side: 'top' });
```

```js
assertTooltipPosition(assert, {
  side: 'top',
  selector: '.test-tooltip',
});
```

```js
assertTooltipPosition(assert, {
  side: 'top',
  selector: '.test-tooltip',
  targetSelector: '.test-tooltip-target',
});
```

The addon's test suite now uses this test helper instead of the previous, private `assertPosition()` method.