### PR TITLE
Spacing test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ This addon exposes testing helpers which can be used inside of the consuming app
 * `assertTooltipRendered(assert)`: asserts if the tooltip has been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element. A tooltip can be rendered but not visible.
 * `assertTooltipNotRendered(assert)`: asserts if the tooltip has not been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element.
 * `assertTooltipSide(assert, { side: 'right' }): asserts that the tooltip is shown on the correct side of the target. Additional options that can be passed are `selector` and `targetSelector`.
+* `assertTooltipSpacing(assert, { side: 'right', spacing: 10 }): asserts that the tooltip is a given distance from the target (on a given side). `side` and `spacing` must be passed. Additional options that can be passed are `selector` and `targetSelector`.
 * `triggerTooltipTargetEvent($targetElement, eventName)`: triggers an event on the passed element. The event will be triggered within an Ember.run so that the tooltip's asynchronicity is accounted for. eventName can be mouseenter, mouseleave, click, focus, focusin, and blur.
 
 Each test helper also accepts an `options` object as a final parameter. If a `selector` property is provided the assertions and actions will be run against the single element found from that selector.

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -100,7 +100,7 @@ function validateSide(side, testHelper = 'assertTooltipSide') {
   }
 }
 
-export function getTooltipPosition(options = {}) {
+function getTooltipPosition(options = {}) {
   const $target = getTooltipTargetFromBody(options.targetSelector);
   const targetPosition = $target[0].getBoundingClientRect();
   const $tooltip = getTooltipFromBody(options.selector);

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -10,7 +10,7 @@ const tooltipOrPopoverTargetSelector = '.ember-tooltip-or-popover-target';
 @param String side The side the tooltip should be on relative to the target
 
 Given a side, which represents the side of the target that
-the tooltip should render on this method identifies whether
+the tooltip should render, this method identifies whether
 the tooltip or the target should be further away from the
 top left of the window.
 
@@ -35,7 +35,7 @@ the target on the given side.
 */
 
 function getPositionDifferences(options = {}) {
-  const { targetPosition, tooltipPosition } = getTooltipPosition(options);
+  const { targetPosition, tooltipPosition } = getTooltipAndTargetPosition(options);
   const { side } = options;
 
   const distanceToTarget = targetPosition[side];
@@ -100,7 +100,7 @@ function validateSide(side, testHelper = 'assertTooltipSide') {
   }
 }
 
-function getTooltipPosition(options = {}) {
+function getTooltipAndTargetPosition(options = {}) {
   const $target = getTooltipTargetFromBody(options.targetSelector);
   const targetPosition = $target[0].getBoundingClientRect();
   const $tooltip = getTooltipFromBody(options.selector);
@@ -214,9 +214,11 @@ export function assertTooltipSpacing(assert, options) {
   target's position is greater than the tooltip's
   position. */
 
-  assert.ok(expectedGreaterDistance > expectedLesserDistance,
-    `Tooltip should be on the ${side} side of the target`);
+  const isSideCorrect = expectedGreaterDistance > expectedLesserDistance;
+  const isSpacingCorrect = actualSpacing === spacing;
 
-  assert.equal(actualSpacing, spacing,
-    `Tooltip should be ${spacing}px from the target but it was ${actualSpacing}px`);
+  assert.ok(isSideCorrect && isSpacingCorrect,
+    `assertTooltipSpacing(): the tooltip should be in the correct position:
+        - Tooltip should be on the ${side} side of the target: ${isSideCorrect}.
+        - On the ${side} side of the target, the tooltip should be ${spacing}px from the target but it was ${actualSpacing}px`);
 }

--- a/tests/integration/components/spacing-test.js
+++ b/tests/integration/components/spacing-test.js
@@ -1,24 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-
-function assertSpacing(assert, context, expectedSpacing) {
-  const $this = context.$();
-  const targetPosition = $this.position();
-  const $tooltip = $this.find('.ember-tooltip');
-  const tooltipPosition = $tooltip.position();
-  const offset = Math.floor(targetPosition.top - tooltipPosition.top);
-
-  const paddingTop = parseInt($tooltip.css('padding-top'));
-  const paddingBottom = parseInt($tooltip.css('padding-bottom'));
-  const actualSpacing = offset - paddingTop - paddingBottom;
-
-  /* Allow a small margin of error because of how browsers
-  render pixels */
-
-  assert.ok(expectedSpacing - 2 < actualSpacing && actualSpacing < expectedSpacing + 2,
-    `Tooltip should be ${expectedSpacing}px from the target`);
-
-}
+import { assertTooltipSpacing } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | spacing', {
   integration: true
@@ -26,24 +8,30 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | spacing', {
 
 test('tooltip-on-element shows with showOn spacing=default', function(assert) {
 
-  assert.expect(1);
+  assert.expect(2);
 
   /* Check the default spacing */
 
   this.render(hbs`{{tooltip-on-element}}`);
 
-  assertSpacing(assert, this, 10);
+  assertTooltipSpacing(assert, {
+    side: 'top',
+    spacing: 10,
+  });
 
 });
 
 test('tooltip-on-element shows with showOn spacing=default', function(assert) {
 
-  assert.expect(1);
+  assert.expect(2);
 
   /* Check custom spacing */
 
   this.render(hbs`{{tooltip-on-element spacing=20}}`);
 
-  assertSpacing(assert, this, 20);
+  assertTooltipSpacing(assert, {
+    side: 'top',
+    spacing: 20,
+  });
 
 });

--- a/tests/integration/components/spacing-test.js
+++ b/tests/integration/components/spacing-test.js
@@ -42,11 +42,38 @@ test('tooltip-on-element shows with spacing=20 and side=right', function(assert)
 
   /* Check custom spacing */
 
-  this.render(hbs`{{tooltip-on-element spacing=20 side='right'}}`);
+  this.render(hbs`
+    {{tooltip-on-element
+      spacing=20
+      side='right'
+      keepInWindow=false
+    }}
+  `);
 
   assertTooltipSpacing(assert, {
     side: 'right',
     spacing: 20,
+  });
+
+});
+
+test('tooltip-on-element shows with spacing=53 and side=bottom', function(assert) {
+
+  assert.expect(1);
+
+  /* Check custom spacing */
+
+  this.render(hbs`
+    {{tooltip-on-element
+      spacing=53
+      side='bottom'
+      keepInWindow=false
+    }}
+  `);
+
+  assertTooltipSpacing(assert, {
+    side: 'bottom',
+    spacing: 53,
   });
 
 });

--- a/tests/integration/components/spacing-test.js
+++ b/tests/integration/components/spacing-test.js
@@ -6,9 +6,9 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | spacing', {
   integration: true
 });
 
-test('tooltip-on-element shows with showOn spacing=default', function(assert) {
+test('tooltip-on-element shows with spacing=default', function(assert) {
 
-  assert.expect(2);
+  assert.expect(1);
 
   /* Check the default spacing */
 
@@ -21,9 +21,9 @@ test('tooltip-on-element shows with showOn spacing=default', function(assert) {
 
 });
 
-test('tooltip-on-element shows with showOn spacing=default', function(assert) {
+test('tooltip-on-element shows with spacing=20', function(assert) {
 
-  assert.expect(2);
+  assert.expect(1);
 
   /* Check custom spacing */
 
@@ -31,6 +31,21 @@ test('tooltip-on-element shows with showOn spacing=default', function(assert) {
 
   assertTooltipSpacing(assert, {
     side: 'top',
+    spacing: 20,
+  });
+
+});
+
+test('tooltip-on-element shows with spacing=20 and side=right', function(assert) {
+
+  assert.expect(1);
+
+  /* Check custom spacing */
+
+  this.render(hbs`{{tooltip-on-element spacing=20 side='right'}}`);
+
+  assertTooltipSpacing(assert, {
+    side: 'right',
     spacing: 20,
   });
 


### PR DESCRIPTION
This PR adds a new public test helper, `assertTooltipSpacing()`. This helper lets you assert that the tooltip is a given number of pixels from the target on a given side on the target.

This is designed to test the [spacing option](https://github.com/sir-dunxalot/ember-tooltips#spacing).

Usage is relatively simple and matches the implementation of existing test helpers:

```js
assertTooltipSpacing(assert, {
  side: 'right',
  spacing: 10, // Tooltip should 10px from right of target
});
```

You can also pass in selectors:

```js
assertTooltipSpacing(assert, {
  side: 'top',
  spacing: 20, // Tooltip should be 20px above target
  targetSelector: '.test-tooltip-target',
  tooltipSelector: '.test-tooltip',
});
```

This PR refactored the recently added `assertTooltipSide()` test helper to make the code more DRY.