### PR TITLE
Spike on assertContent test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ This addon exposes testing helpers which can be used inside of the consuming app
 * `assertTooltipNotRendered(assert)`: asserts if the tooltip has not been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element.
 * `assertTooltipSide(assert, { side: 'right' }): asserts that the tooltip is shown on the correct side of the target. Additional options that can be passed are `selector` and `targetSelector`.
 * `assertTooltipSpacing(assert, { side: 'right', spacing: 10 }): asserts that the tooltip is a given distance from the target (on a given side). `side` and `spacing` must be passed. Additional options that can be passed are `selector` and `targetSelector`.
+* `assertContent(assert, contentString): asserts that the content of the tooltip matches a given string. 
 * `triggerTooltipTargetEvent($targetElement, eventName)`: triggers an event on the passed element. The event will be triggered within an Ember.run so that the tooltip's asynchronicity is accounted for. eventName can be mouseenter, mouseleave, click, focus, focusin, and blur.
 
 Each test helper also accepts an `options` object as a final parameter. If a `selector` property is provided the assertions and actions will be run against the single element found from that selector.

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ This addon exposes testing helpers which can be used inside of the consuming app
 * `assertTooltipNotRendered(assert)`: asserts if the tooltip has not been rendered. When enableLazyRendering is true the tooltip will only be rendered after the user has interacted with the $target element.
 * `assertTooltipSide(assert, { side: 'right' }): asserts that the tooltip is shown on the correct side of the target. Additional options that can be passed are `selector` and `targetSelector`.
 * `assertTooltipSpacing(assert, { side: 'right', spacing: 10 }): asserts that the tooltip is a given distance from the target (on a given side). `side` and `spacing` must be passed. Additional options that can be passed are `selector` and `targetSelector`.
-* `assertContent(assert, contentString): asserts that the content of the tooltip matches a given string. 
+* `assertContent(assert, { contentString: 'hello' }): asserts that the content of the tooltip matches a given string. 
 * `triggerTooltipTargetEvent($targetElement, eventName)`: triggers an event on the passed element. The event will be triggered within an Ember.run so that the tooltip's asynchronicity is accounted for. eventName can be mouseenter, mouseleave, click, focus, focusin, and blur.
 
 Each test helper also accepts an `options` object as a final parameter. If a `selector` property is provided the assertions and actions will be run against the single element found from that selector.

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -222,3 +222,14 @@ export function assertTooltipSpacing(assert, options) {
         - Tooltip should be on the ${side} side of the target: ${isSideCorrect}.
         - On the ${side} side of the target, the tooltip should be ${spacing}px from the target but it was ${actualSpacing}px`);
 }
+
+export function assertContent(assert, contentString, options = {}) {
+  const $tooltip = getTooltipFromBody(options.selector);
+  const tooltipContent = $tooltip.text().trim();
+
+  assert.equal(
+    tooltipContent,
+    contentString,
+    `Content of tooltip (${tooltipContent}) matched expected (${contentString})`
+  );
+}

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -223,7 +223,8 @@ export function assertTooltipSpacing(assert, options) {
         - On the ${side} side of the target, the tooltip should be ${spacing}px from the target but it was ${actualSpacing}px`);
 }
 
-export function assertContent(assert, contentString, options = {}) {
+export function assertTooltipContent(assert, options = {}) {
+  const { contentString } = options;
   const $tooltip = getTooltipFromBody(options.selector);
   const tooltipContent = $tooltip.text().trim();
 

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -226,16 +226,12 @@ export function assertTooltipSpacing(assert, options) {
 export function assertTooltipContent(assert, options = {}) {
   const { contentString } = options;
 
-  if (contentString === undefined) {
+  if (Ember.isNone(contentString)) {
     Ember.assert('You must specify a contentString property in the options parameter');
   }
 
   const $tooltip = getTooltipFromBody(options.selector);
   const tooltipContent = $tooltip.text().trim();
 
-  assert.equal(
-    tooltipContent,
-    contentString,
-    `Content of tooltip (${tooltipContent}) matched expected (${contentString})`
-  );
+  assert.equal(tooltipContent, contentString, `Content of tooltip (${tooltipContent}) matched expected (${contentString})`);
 }

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -225,6 +225,11 @@ export function assertTooltipSpacing(assert, options) {
 
 export function assertTooltipContent(assert, options = {}) {
   const { contentString } = options;
+
+  if (contentString === undefined) {
+    Ember.assert('You must specify a contentString property in the options parameter');
+  }
+
   const $tooltip = getTooltipFromBody(options.selector);
   const tooltipContent = $tooltip.text().trim();
 

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { assertTooltipContent } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | content', {
-  integration: true
+  integration: true,
 });
 
 test('assertTooltipContent correctly matches expected tootltip content', function(assert) {
@@ -18,7 +18,7 @@ test('assertTooltipContent correctly matches expected tootltip content', functio
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'Smiley face'
+    contentString: 'Smiley face',
   });
 
   this.render(hbs`
@@ -31,7 +31,7 @@ test('assertTooltipContent correctly matches expected tootltip content', functio
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'Frowning face'
+    contentString: 'Frowning face',
   });
 });
 
@@ -47,7 +47,7 @@ test('assertTooltipContent correctly compares expected and discovered tooltip co
   `);
 
   const stubbedAssert = {
-    equal(arg1, arg2/*, msg*/) {
+    equal(arg1, arg2/* , msg */) {
       assert.equal(
         arg1,
         'Smiley face',
@@ -59,10 +59,10 @@ test('assertTooltipContent correctly compares expected and discovered tooltip co
         'Frowning face',
         'Helper correctly intends to compare to string we provide'
       );
-    }
+    },
   };
 
   assertTooltipContent(stubbedAssert, {
-    contentString: 'Frowning face'
+    contentString: 'Frowning face',
   });
 });

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -1,12 +1,12 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertContent } from '../../helpers/ember-tooltips';
+import { assertTooltipContent } from '../../helpers/ember-tooltips';
 
-moduleForComponent('tooltip-on-element', 'Integration | Option | content ryanlabouve', {
+moduleForComponent('tooltip-on-element', 'Integration | Option | content', {
   integration: true
 });
 
-test('assertContent correctly matches expected content', function(assert) {
+test('assertTooltipContent correctly matches expected tootltip content', function(assert) {
 
   assert.expect(1);
 
@@ -17,10 +17,12 @@ test('assertContent correctly matches expected content', function(assert) {
     </div>
   `);
 
-  assertContent(assert, 'Smiley face');
+  assertTooltipContent(assert, {
+    contentString: 'Smiley face'
+  });
 });
 
-test('assertContent correctly compares expected and discovered content of tooltip', function(assert) {
+test('assertTooltipContent correctly compares expected and discovered tooltip content of tooltip', function(assert) {
 
   assert.expect(2);
 
@@ -47,5 +49,7 @@ test('assertContent correctly compares expected and discovered content of toolti
     }
   };
 
-  assertContent(stubbedAssert, 'Frowning face');
+  assertTooltipContent(stubbedAssert, {
+    contentString: 'Frowning face'
+  });
 });

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -8,7 +8,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Option | content', {
 
 test('assertTooltipContent correctly matches expected tootltip content', function(assert) {
 
-  assert.expect(1);
+  assert.expect(2);
 
   this.render(hbs`
     <div>
@@ -19,6 +19,19 @@ test('assertTooltipContent correctly matches expected tootltip content', functio
 
   assertTooltipContent(assert, {
     contentString: 'Smiley face'
+  });
+
+  this.render(hbs`
+    <div>
+      :(
+      {{#tooltip-on-element}}
+        Frowning face
+      {{/tooltip-on-element}}
+    </div>
+  `);
+
+  assertTooltipContent(assert, {
+    contentString: 'Frowning face'
   });
 });
 

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -10,28 +10,16 @@ test('assertTooltipContent correctly matches expected tootltip content', functio
 
   assert.expect(2);
 
-  this.render(hbs`
-    <div>
-      :)
-      {{tooltip-on-element text='Smiley face'}}
-    </div>
-  `);
+  this.render(hbs`{{tooltip-on-element text='foo'}}`);
 
   assertTooltipContent(assert, {
-    contentString: 'Smiley face',
+    contentString: 'foo',
   });
 
-  this.render(hbs`
-    <div>
-      :(
-      {{#tooltip-on-element}}
-        Frowning face
-      {{/tooltip-on-element}}
-    </div>
-  `);
+  this.render(hbs`{{#tooltip-on-element}}foo{{/tooltip-on-element}}`);
 
   assertTooltipContent(assert, {
-    contentString: 'Frowning face',
+    contentString: 'foo',
   });
 });
 
@@ -39,30 +27,25 @@ test('assertTooltipContent correctly compares expected and discovered tooltip co
 
   assert.expect(2);
 
-  this.render(hbs`
-    <div>
-      :)
-      {{tooltip-on-element text='Smiley face'}}
-    </div>
-  `);
+  this.render(hbs`{{tooltip-on-element text='foo'}}`);
 
   const stubbedAssert = {
     equal(arg1, arg2/* , msg */) {
       assert.equal(
         arg1,
-        'Smiley face',
+        'foo',
         'Helper correctly finds actual content of tooltip'
       );
 
       assert.equal(
         arg2,
-        'Frowning face',
+        'foo',
         'Helper correctly intends to compare to string we provide'
       );
     },
   };
 
   assertTooltipContent(stubbedAssert, {
-    contentString: 'Frowning face',
+    contentString: 'foo',
   });
 });

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -1,0 +1,51 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { assertContent } from '../../helpers/ember-tooltips';
+
+moduleForComponent('tooltip-on-element', 'Integration | Option | content ryanlabouve', {
+  integration: true
+});
+
+test('assertContent correctly matches expected content', function(assert) {
+
+  assert.expect(1);
+
+  this.render(hbs`
+    <div>
+      :)
+      {{tooltip-on-element text='Smiley face'}}
+    </div>
+  `);
+
+  assertContent(assert, 'Smiley face');
+});
+
+test('assertContent correctly compares expected and discovered content of tooltip', function(assert) {
+
+  assert.expect(2);
+
+  this.render(hbs`
+    <div>
+      :)
+      {{tooltip-on-element text='Smiley face'}}
+    </div>
+  `);
+
+  const stubbedAssert = {
+    equal(arg1, arg2/*, msg*/) {
+      assert.equal(
+        arg1,
+        'Smiley face',
+        'Helper correctly finds actual content of tooltip'
+      );
+
+      assert.equal(
+        arg2,
+        'Frowning face',
+        'Helper correctly intends to compare to string we provide'
+      );
+    }
+  };
+
+  assertContent(stubbedAssert, 'Frowning face');
+});

--- a/tests/integration/components/popover/popover-on-component-test.js
+++ b/tests/integration/components/popover/popover-on-component-test.js
@@ -1,6 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipNotRendered, assertTooltipRendered } from '../../../helpers/ember-tooltips';
+import {
+  assertTooltipNotRendered,
+  assertTooltipRendered,
+  assertTooltipContent
+} from '../../../helpers/ember-tooltips';
+
 
 moduleForComponent('popover-on-component', 'Integration | Component | popover on component', {
   integration: true,
@@ -8,7 +13,7 @@ moduleForComponent('popover-on-component', 'Integration | Component | popover on
 
 test('popover-on-component does render when enableLazyRendering=false', function(assert) {
 
-  assert.expect(1);
+  assert.expect(2);
 
   this.render(hbs`
     {{#some-component}}
@@ -17,6 +22,10 @@ test('popover-on-component does render when enableLazyRendering=false', function
       {{/popover-on-component}}
     {{/some-component}}
   `);
+
+  assertTooltipContent(assert, {
+    contentString: 'template block text'
+  });
 
   assertTooltipRendered(assert);
 });

--- a/tests/integration/components/popover/popover-on-component-test.js
+++ b/tests/integration/components/popover/popover-on-component-test.js
@@ -3,9 +3,8 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotRendered,
   assertTooltipRendered,
-  assertTooltipContent
+  assertTooltipContent,
 } from '../../../helpers/ember-tooltips';
-
 
 moduleForComponent('popover-on-component', 'Integration | Component | popover on component', {
   integration: true,
@@ -24,7 +23,7 @@ test('popover-on-component does render when enableLazyRendering=false', function
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'template block text'
+    contentString: 'template block text',
   });
 
   assertTooltipRendered(assert);

--- a/tests/integration/components/text-test.js
+++ b/tests/integration/components/text-test.js
@@ -15,7 +15,7 @@ test('tooltip-on-element renders with text param', function(assert) {
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'Here is more info'
+    contentString: 'Here is more info',
   });
 
   assertTooltipRendered(assert);

--- a/tests/integration/components/text-test.js
+++ b/tests/integration/components/text-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipRendered } from '../../helpers/ember-tooltips';
+import { assertTooltipRendered, assertTooltipContent } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Component | inline', {
   integration: true,
@@ -14,9 +14,9 @@ test('tooltip-on-element renders with text param', function(assert) {
     {{tooltip-on-element text='Here is more info'}}
   `);
 
-  assert.equal(this.$().text().trim(), 'Here is more info',
-    'Should render with content equal to the text property');
+  assertTooltipContent(assert, {
+    contentString: 'Here is more info'
+  });
 
   assertTooltipRendered(assert);
-
 });

--- a/tests/integration/components/tooltip-on-component-test.js
+++ b/tests/integration/components/tooltip-on-component-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotRendered,
   assertTooltipRendered,
-  assertTooltipContent
+  assertTooltipContent,
 } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-component', 'Integration | Component | tooltip-on-component', {
@@ -23,7 +23,7 @@ test('tooltip-on-component does render when enableLazyRendering=false', function
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'template block text'
+    contentString: 'template block text',
   });
 
   assertTooltipRendered(assert);

--- a/tests/integration/components/tooltip-on-component-test.js
+++ b/tests/integration/components/tooltip-on-component-test.js
@@ -1,12 +1,18 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipNotRendered, assertTooltipRendered } from '../../helpers/ember-tooltips';
+import {
+  assertTooltipNotRendered,
+  assertTooltipRendered,
+  assertTooltipContent
+} from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-component', 'Integration | Component | tooltip-on-component', {
   integration: true,
 });
 
 test('tooltip-on-component does render when enableLazyRendering=false', function(assert) {
+
+  assert.expect(2);
 
   this.render(hbs`
     {{#some-component}}
@@ -16,11 +22,16 @@ test('tooltip-on-component does render when enableLazyRendering=false', function
     {{/some-component}}
   `);
 
-  assertTooltipRendered(assert);
+  assertTooltipContent(assert, {
+    contentString: 'template block text'
+  });
 
+  assertTooltipRendered(assert);
 });
 
 test('tooltip-on-component does not eagerly render when enableLazyRendering=true', function(assert) {
+
+  assert.expect(1);
 
   this.render(hbs`
     {{#some-component}}

--- a/tests/integration/components/tooltip-on-element-test.js
+++ b/tests/integration/components/tooltip-on-element-test.js
@@ -43,7 +43,6 @@ test('tooltip-on-element has the proper aria-describedby tag', function(assert) 
   const describedBy = $tooltipTarget.attr('aria-describedby');
 
   assertTooltipContent(assert, {
-    // targetSelector: '.target',
     selector: `#${describedBy}`,
     contentString: 'Some info in a tooltip.'
   });

--- a/tests/integration/components/tooltip-on-element-test.js
+++ b/tests/integration/components/tooltip-on-element-test.js
@@ -2,6 +2,8 @@ import { moduleForComponent, test } from 'ember-qunit';
 import { assertTooltipRendered } from '../../helpers/ember-tooltips';
 import hbs from 'htmlbars-inline-precompile';
 
+import { assertTooltipContent } from '../../helpers/ember-tooltips';
+
 moduleForComponent('tooltip-on-element', 'Integration | Component | tooltip on element', {
   integration: true,
 });
@@ -16,11 +18,11 @@ test('tooltip-on-element renders', function(assert) {
     {{/tooltip-on-element}}
   `);
 
-  assert.equal(this.$().text().trim(), 'template block text',
-    'Should render with content');
+  assertTooltipContent(assert, {
+    contentString: 'template block text'
+  });
 
   assertTooltipRendered(assert);
-
 });
 
 test('tooltip-on-element has the proper aria-describedby tag', function(assert) {
@@ -40,7 +42,11 @@ test('tooltip-on-element has the proper aria-describedby tag', function(assert) 
   const $tooltipTarget = this.$('.target');
   const describedBy = $tooltipTarget.attr('aria-describedby');
 
-  assert.equal(this.$(`#${describedBy}`).text().trim(), 'Some info in a tooltip.');
+  assertTooltipContent(assert, {
+    // targetSelector: '.target',
+    selector: `#${describedBy}`,
+    contentString: 'Some info in a tooltip.'
+  });
   assert.equal(describedBy.indexOf('#'), '-1');
 
 });

--- a/tests/integration/components/tooltip-on-element-test.js
+++ b/tests/integration/components/tooltip-on-element-test.js
@@ -19,7 +19,7 @@ test('tooltip-on-element renders', function(assert) {
   `);
 
   assertTooltipContent(assert, {
-    contentString: 'template block text'
+    contentString: 'template block text',
   });
 
   assertTooltipRendered(assert);
@@ -44,7 +44,7 @@ test('tooltip-on-element has the proper aria-describedby tag', function(assert) 
 
   assertTooltipContent(assert, {
     selector: `#${describedBy}`,
-    contentString: 'Some info in a tooltip.'
+    contentString: 'Some info in a tooltip.',
   });
   assert.equal(describedBy.indexOf('#'), '-1');
 

--- a/tests/integration/components/update-for-test.js
+++ b/tests/integration/components/update-for-test.js
@@ -3,6 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 const { RSVP, run } = Ember;
+import { assertTooltipContent } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | updateFor', {
   integration: true,
@@ -34,14 +35,16 @@ test('updateFor test', function(assert) {
   `);
 
   const done = assert.async();
-  const $tooltip = this.$();
 
-  assert.equal($tooltip.text().trim(), '...',
-    'Should render ...');
+  assertTooltipContent(assert, {
+    contentString: '...'
+  });
 
   run.later(() => {
-    assert.equal($tooltip.text().trim(), 'Some model',
-      'Should render "Some model"');
+    assertTooltipContent(assert, {
+      contentString: 'Some model'
+    });
+
     done();
   }, 200);
 

--- a/tests/integration/components/update-for-test.js
+++ b/tests/integration/components/update-for-test.js
@@ -2,7 +2,11 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { RSVP, run } = Ember;
+const {
+  RSVP,
+  run,
+} = Ember;
+
 import { assertTooltipContent } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | updateFor', {
@@ -37,12 +41,12 @@ test('updateFor test', function(assert) {
   const done = assert.async();
 
   assertTooltipContent(assert, {
-    contentString: '...'
+    contentString: '...',
   });
 
   run.later(() => {
     assertTooltipContent(assert, {
-      contentString: 'Some model'
+      contentString: 'Some model',
     });
 
     done();


### PR DESCRIPTION
This PR adds  an `assertContent(assert, contentString, options)` test helper to allow assertion on the content of a tooltip.

This may be a basic implementation, but would love feedback on how to improve.

Also, I feel like I should add additional tests to cover passing in at least the selector options.

Is this heading in the right direction? 


(This relates to https://github.com/sir-dunxalot/ember-tooltips/issues/128)