### PR TITLE
add level to #some-component, proper $target for lazy-render-wrapper, tests

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import layout from 'ember-tooltips/templates/components/lazy-render-wrapper';
 
 const { computed, get, $ } = Ember;
+export const targetEventNameSpace = 'target-lazy-render-wrapper';
 
 // https://github.com/emberjs/rfcs/issues/168
 // https://github.com/emberjs/ember.js/pull/12500
@@ -142,6 +143,14 @@ export default Ember.Component.extend({
 		return _lazyRenderEvents;
 	}),
 
+	/**
+	 * A jQuery element that the _lazyRenderEvents will be
+	 * attached to during didInsertElement and
+	 * removed from during willDestroyElement
+	 * @property $target
+	 * @type jQuery element
+	 * @default the parent jQuery element
+	 */
 	$target: computed('target', 'tetherComponentName', function() {
 		const target = this.get('target'); // #some-id
 		let $target;
@@ -151,7 +160,17 @@ export default Ember.Component.extend({
 		} else if (this.get('tetherComponentName').indexOf('-on-component') >= 0) {
 			// TODO(Andrew) refactor this once we've gotten rid of the -on-component approach
 			// share the functionality with `onComponentTarget`
-			const targetViewElementId = this.get('parentView.elementId');
+			const targetView = this.get('parentView');
+
+			if (!targetView) {
+				console.warn('No targetView found');
+				return null;
+			} else if (!targetView.get('elementId')) {
+				console.warn('No targetView.elementId');
+				return null;
+			}
+
+			const targetViewElementId = targetView.get('elementId');
 			$target = $(`#${targetViewElementId}`);
 		} else {
 			$target = getParent(this);
@@ -160,7 +179,6 @@ export default Ember.Component.extend({
 		return $target;
 	}),
 
-	_targetEventNameSpace: 'target-lazy-render-wrapper',
 	didInsertElement() {
 		this._super(...arguments);
 
@@ -171,21 +189,20 @@ export default Ember.Component.extend({
 		}
 
 		let $target = this.get('$target');
-		let _targetEventNameSpace = this.get('_targetEventNameSpace');
 
 		if (this.get('event') === 'hover') {
 			// We've seen instances where a user quickly mouseenter and mouseleave the $target.
 			// By providing this event handler we ensure that the tooltip will only *show*
 			// if the user has mouseenter and not mouseleave immediately afterwards.
-			$target.on(`mouseleave.${_targetEventNameSpace}`, () => {
+			$target.on(`mouseleave.${targetEventNameSpace}`, () => {
 				this.set('_shouldShowOnRender', false);
 			});
 		}
 
 		this.get('_lazyRenderEvents').forEach((entryInteractionEvent) => {
-			$target.on(`${entryInteractionEvent}.${_targetEventNameSpace}`, () => {
+			$target.on(`${entryInteractionEvent}.${targetEventNameSpace}`, () => {
 				if (this.get('_hasUserInteracted')) {
-					$target.off(`${entryInteractionEvent}.${_targetEventNameSpace}`);
+					$target.off(`${entryInteractionEvent}.${targetEventNameSpace}`);
 				} else {
 					this.set('_hasUserInteracted', true);
 					this.set('_shouldShowOnRender', true);
@@ -211,11 +228,10 @@ export default Ember.Component.extend({
 		this._super(...arguments);
 
 		const $target = this.get('$target');
-		const _targetEventNameSpace = this.get('_targetEventNameSpace');
 		this.get('_lazyRenderEvents').forEach((entryInteractionEvent) => {
-			$target.off(`${entryInteractionEvent}.${_targetEventNameSpace}`);
+			$target.off(`${entryInteractionEvent}.${targetEventNameSpace}`);
 		});
 
-		$target.off(`mouseleave.${_targetEventNameSpace}`);
+		$target.off(`mouseleave.${targetEventNameSpace}`);
 	},
 });

--- a/tests/dummy/app/templates/components/some-component.hbs
+++ b/tests/dummy/app/templates/components/some-component.hbs
@@ -1,0 +1,6 @@
+{{!-- an extra div is needed so that the -on-component tests
+are actually grabbing the parentView, which is not necessarily
+always the parent element --}}
+<div>
+	{{yield}}
+</div>

--- a/tests/integration/components/render-events-test.js
+++ b/tests/integration/components/render-events-test.js
@@ -1,0 +1,127 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('tooltip-on-element', 'Integration | Component | event handlers', {
+  integration: true
+});
+
+
+function assertTargetHasLazyRenderEvents(assert, $target, eventType="hover") {
+  const eventsObject = $._data($target[0], 'events');
+
+  function assertEventExists(event) {
+    // for some reason mouseenter events are stored as mouseover in the eventsObject
+    // same for mouseleave -> mouse out
+    let eventObjectName = event;
+    if (event === 'mouseenter') {
+      eventObjectName = 'mouseover';
+    } else if (event === 'mouseleave') {
+      eventObjectName = 'mouseout';
+    }
+
+    assert.ok(eventsObject && eventsObject[eventObjectName],
+        `the eventsObject exists and should have ${eventObjectName} event`);
+
+    let eventHandler = eventsObject[eventObjectName][0];
+    assert.equal(eventHandler.origType, event,
+        `the eventHandler's origType property should equal ${event}`);
+
+    assert.ok(eventHandler.namespace.indexOf('target-lazy-render-wrapper') >= 0,
+        'the eventHandler\'s namespace property be unique to ember-tooltips');
+  }
+
+  function assertNumEventsExist(num) {
+    let numEvents = Object.keys(eventsObject || {}).reduce(function(n, keyName) {
+      return n + eventsObject[keyName].length;
+    }, 0);
+
+    assert.equal(num, numEvents,
+        `${num} events should exist`);
+  }
+
+  if (eventType === 'hover') {
+    assertNumEventsExist(3);
+    assertEventExists('focusin');
+    assertEventExists('mouseenter');
+    assertEventExists('mouseleave');
+  } else if (eventType === 'click') {
+    assertNumEventsExist(2);
+    assertEventExists('focusin');
+    assertEventExists('click');
+  } else if (eventType === 'focus') {
+    assertNumEventsExist(1);
+    assertEventExists('focusin');
+  } else if (eventType === 'none') {
+    assertNumEventsExist(0);
+  }
+}
+
+
+['hover', 'click', 'focus', 'none'].forEach(function(eventType) {
+  test(`lazy-render-wrapper correctly assigns event handlers when event=${eventType}`, function(assert) {
+
+    this.set('eventType', eventType);
+
+    this.render(hbs`{{tooltip-on-element event=eventType enableLazyRendering=true}}`);
+
+    const $target = this.$();
+
+    assertTargetHasLazyRenderEvents(assert, $target, eventType);
+
+  });
+});
+
+
+test('lazy-render-wrapper correctly assigns event handlers when target="some-id"', function(assert) {
+
+  this.render(hbs`
+    <div id="some-id"></div>
+    {{tooltip-on-element target="#some-id" enableLazyRendering=true}}
+  `);
+
+  const $target = this.$('#some-id');
+
+  assertTargetHasLazyRenderEvents(assert, $target);
+
+});
+
+
+test('lazy-render-wrapper correctly assigns event handlers when -on-component', function(assert) {
+
+  this.render(hbs`
+    {{#some-component}}
+      {{tooltip-on-component enableLazyRendering=true}}
+    {{/some-component}}
+  `);
+
+  const $target = this.$('.some-component');
+
+  assertTargetHasLazyRenderEvents(assert, $target);
+
+});
+
+
+test('lazy-render-wrapper removes event handlers when -on-component is destroyed', function(assert) {
+
+  this.render(hbs`
+    {{#some-component}}
+      {{#unless deleteTooltip}}
+        {{tooltip-on-component enableLazyRendering=true}}
+      {{/unless}}
+    {{/some-component}}
+  `);
+
+  const $target = this.$('.some-component');
+  const done = assert.async();
+
+  assertTargetHasLazyRenderEvents(assert, $target);
+
+  this.set('deleteTooltip', true);
+
+  Ember.run.later(() => {
+    assertTargetHasLazyRenderEvents(assert, $target, 'none');
+    done();
+  }, 1000);
+
+});

--- a/tests/integration/components/render-events-test.js
+++ b/tests/integration/components/render-events-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { targetEventNameSpace } from 'ember-tooltips/components/lazy-render-wrapper';
 
 moduleForComponent('tooltip-on-element', 'Integration | Component | event handlers', {
   integration: true
@@ -27,11 +28,15 @@ function assertTargetHasLazyRenderEvents(assert, $target, eventType="hover") {
     assert.equal(eventHandler.origType, event,
         `the eventHandler's origType property should equal ${event}`);
 
-    assert.ok(eventHandler.namespace.indexOf('target-lazy-render-wrapper') >= 0,
+    assert.ok(eventHandler.namespace.indexOf(targetEventNameSpace) >= 0,
         'the eventHandler\'s namespace property be unique to ember-tooltips');
   }
 
   function assertNumEventsExist(num) {
+    // This function asserts that a certain number of event handlers are attached to an object.
+    // Event handlers are stored in arrays on the eventsObject like so...
+    // eventsObject = { focusin: [x, x], click: [x] } would equal 3 events
+
     let numEvents = Object.keys(eventsObject || {}).reduce(function(n, keyName) {
       return n + eventsObject[keyName].length;
     }, 0);


### PR DESCRIPTION
this addresses the bugs identified in this ticket https://github.com/sir-dunxalot/ember-tooltips/issues/138

notale improvements...
* lazy-render-wrapper [will now get](https://github.com/sir-dunxalot/ember-tooltips/pull/149/files#diff-8096b1ffac251e79ea18b7393d9f241fR145) the correct $target element, which may be different when using `<x>-on-component`, `<x>-on-element`, and when `target="some-id"`
  * [before](https://github.com/sir-dunxalot/ember-tooltips/pull/149/files#diff-8096b1ffac251e79ea18b7393d9f241fL148) it was always getting the parentElement
* renamed `entryInteractionEvents` to `_lazyRenderEvents`
* added [_targetEventNameSpace](https://github.com/sir-dunxalot/ember-tooltips/pull/149/files#diff-8096b1ffac251e79ea18b7393d9f241fR163) to keep the code DRY
* willDestroyElement also references `$target` to clean up event handlers
* added an empty `<div>` to `some-component`, which adds extra robustness for `-on-component` tests while maintaining the same UI in the dummy site
* added `render-events-test.js`
