### PR TITLE
pointer-events: auto; is the correct CSS to use

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -18,7 +18,7 @@
 }
 
 .ember-popover[aria-hidden="false"] {
-  pointer-events: initial;
+  pointer-events: auto;
   cursor: initial;
   -webkit-touch-callout: auto;
   -webkit-user-select: auto;


### PR DESCRIPTION
https://github.com/sir-dunxalot/ember-tooltips/issues/158

`pointer-events: initial;` was not working in IE. Setting it to `initial` was a mistake and I always wanted the behavior from the `auto` value.

https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events


### gif in IE after fix
![popover in ie](https://cloud.githubusercontent.com/assets/7050871/21737398/023f413e-d42d-11e6-9536-b827fa69bfa1.gif)
