### PR TITLE
A15n/fix eslint order warning

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -11,7 +11,7 @@ const {
   warn,
 } = Ember;
 
-export const targetEventNameSpace = 'target-lazy-render-wrapper';
+export const TARGET_EVENT_NAMESPACE = 'target-lazy-render-wrapper';
 
 /* Beware: use of private API! :(
 
@@ -84,7 +84,7 @@ export default Component.extend({
   layout,
   enableLazyRendering: false,
   event: 'hover', // Options are: hover, click, focus, none
-  childView: null, // This is set during the childView's didRender and is needed for the hide action
+  _childView: null, // This is set during the childView's didRender and is needed for the hide action
 
   _hasUserInteracted: false,
   _hasRendered: false,
@@ -247,15 +247,15 @@ export default Component.extend({
       if the user has mouseenter and not mouseleave immediately afterwards.
       */
 
-      $target.on(`mouseleave.${targetEventNameSpace}`, () => {
+      $target.on(`mouseleave.${TARGET_EVENT_NAMESPACE}`, () => {
         this.set('_shouldShowOnRender', false);
       });
     }
 
-    this.get('_lazyRenderEvents').forEach((entryInteractionEvent) => {
-      $target.on(`${entryInteractionEvent}.${targetEventNameSpace}`, () => {
+    this.get('_lazyRenderEvents').forEach((_lazyRenderEvent) => {
+      $target.on(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`, () => {
         if (this.get('_hasUserInteracted')) {
-          $target.off(`${entryInteractionEvent}.${targetEventNameSpace}`);
+          $target.off(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`);
         } else {
           this.set('_hasUserInteracted', true);
           this.set('_shouldShowOnRender', true);
@@ -270,25 +270,25 @@ export default Component.extend({
 
     const $target = this.get('$target');
 
-    this.get('_lazyRenderEvents').forEach((entryInteractionEvent) => {
-      $target.off(`${entryInteractionEvent}.${targetEventNameSpace}`);
+    this.get('_lazyRenderEvents').forEach((_lazyRenderEvent) => {
+      $target.off(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`);
     });
 
-    $target.off(`mouseleave.${targetEventNameSpace}`);
+    $target.off(`mouseleave.${TARGET_EVENT_NAMESPACE}`);
   },
 
   /* 7. All actions */
 
   actions: {
     hide() {
-      const childView = this.get('childView');
+      const _childView = this.get('_childView');
 
-      /* The childView.actions property is not available in Ember 1.13
-      We will use childView._actions until we drop support for Ember 1.13
+      /* The _childView.actions property is not available in Ember 1.13
+      We will use _childView._actions until we drop support for Ember 1.13
       */
 
-      if (childView && childView._actions && childView._actions.hide) {
-        childView.send('hide');
+      if (_childView && _childView._actions && _childView._actions.hide) {
+        _childView.send('hide');
       }
     },
   },

--- a/addon/components/tether-popover-on-element.js
+++ b/addon/components/tether-popover-on-element.js
@@ -95,7 +95,7 @@ export default TooltipAndPopoverComponent.extend({
     const parentView = this.get('parentView');
 
     if (parentView) {
-      parentView.set('childView', this);
+      parentView.set('_childView', this);
     }
   },
   didInsertElement() {

--- a/tests/integration/components/render-events-test.js
+++ b/tests/integration/components/render-events-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { targetEventNameSpace } from 'ember-tooltips/components/lazy-render-wrapper';
+import { TARGET_EVENT_NAMESPACE } from 'ember-tooltips/components/lazy-render-wrapper';
 
 const { $, run } = Ember;
 
@@ -34,7 +34,7 @@ function assertTargetHasLazyRenderEvents(assert, $target, eventType = 'hover') {
     assert.equal(eventHandler.origType, event,
         `the eventHandler's origType property should equal ${event}`);
 
-    assert.ok(eventHandler.namespace.indexOf(targetEventNameSpace) >= 0,
+    assert.ok(eventHandler.namespace.indexOf(TARGET_EVENT_NAMESPACE) >= 0,
         'the eventHandler\'s namespace property be unique to ember-tooltips');
   }
 


### PR DESCRIPTION
* Fixes the ESLint issue raised here (https://github.com/sir-dunxalot/ember-tooltips/issues/163)
  * guidelines https://github.com/netguru/ember-styleguide#organize-your-components
* changes some variable names to `TARGET_EVENT_NAMESPACE `, `_childView`, and `_lazyRenderEvent ` for better clarity (see https://github.com/sir-dunxalot/ember-tooltips/pull/171/commits/1e5339a68703f6ce962af81de20d0fea517286a1)
* no logic changes