### PR TITLE
Change font-family to inherit

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -6,7 +6,7 @@
   pointer-events: none;
 
   font-size: 14px;
-  font-family: sans-serif;
+  font-family: inherit;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Updates the following value of `font-family` in the addon's CSS:

```css
.ember-tooltip,
.ember-popover {
  font-family: inherit; /* sans-serif --> inherit */
}
```