### PR TITLE
Remove compass boilerplate

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,9 +8,6 @@ module.exports = function(defaults) {
 
     sassOptions: {
       extension: 'scss',
-      includePaths: [
-        'node_modules/compass-boilerplate/lib',
-      ],
     },
 
   });

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "compass-boilerplate": "^0.1.2",
-    "compass-mixins": "^0.12.10",
     "ember-ajax": "2.0.1",
     "ember-cli": "^2.6.3",
     "ember-cli-app-version": "^1.0.0",

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,7 +1,3 @@
-@import 'compass-boilerplate-vendor/normalize';
-@import 'compass-boilerplate-vendor/html5bp';
-@import 'compass-boilerplate';
-
 @import 'variables';
 @import 'components/code';
 
@@ -10,7 +6,7 @@ html {
 }
 
 body {
-  @include rem(font-size, $bodyFontSize);
+  font-size: #{$bodyFontSize}rem;
 
   /* So text looks much better in Crome/Safari */
 
@@ -40,29 +36,29 @@ h3 {
   background-image: linear-gradient(-134deg, #3023AE 0%, #A56DD7 100%);
   -webkit-display: flex;
   display: flex;
-  @include justify-content(center);
-  @include align-items(center);
-  @include flex-direction(column);
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 }
 
 #ember-logo {
   width: 200px;
   height: auto;
-  @include rem(margin-right, 10);
-  @include inline-block;
+  margin-right: 10rem;
+  display: inline-block;
 }
 
 .badges {
-  @include rem(margin-top, 4);
+  margin-top: 4rem;
   text-align: center;
 
   a + * {
-    @include rem(margin-left, 1);
+    margin-left: 1rem;
   }
 }
 
 .logo-tooltip {
-  @include rem(font-size, 2);
+  font-size: 2rem;
   top: 16px !important;
 }
 
@@ -71,7 +67,7 @@ h3 {
   $_gutter: 10px;
 
   width: 100%;
-  @include rem(padding, $spacing);
+  padding: 3rem;
   padding-left: calc((100% - #{$_width}) / 2);
   padding-right: calc((100% - #{$_width}) / 2);
   box-sizing: border-box;
@@ -85,24 +81,24 @@ h3 {
 
 .some-component {
   border: 1px solid #666;
-  @include rem(border-radius, 0.3);
-  @include inline-block;
-  @include rem(padding, 0.6, 1);
+  border-radius: 0.3rem;
+  display: inline-block;
+  padding: 0.6rem 1rem;
   cursor: pointer;
   background-color: rgba($white, 0.5);
   position: relative;
 }
 
 hr {
-  @include rem(margin, 6, 0);
+  margin: 6rem 0;
 }
 
 input {
-  @include rem(padding, 0.4, 0.6);
+  padding: 0.4rem 0.6rem;
 }
 
 p {
-  @include rem(margin, 3, 0);
+  margin: 3rem 0rem;
 }
 
 a {
@@ -112,12 +108,12 @@ a {
 }
 
 li {
-  @include rem(padding, 0.4, 0);
+  padding: 0.4rem 0rem;
 }
 
 .ember-popover {
   h3, p {
-    @include rem(margin, 1, 0);
+    margin: 1rem 0;
   }
 
   h3 {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -101,7 +101,7 @@ input {
 }
 
 p {
-  margin: 3rem 0rem;
+  margin: 3rem 0;
 }
 
 a {
@@ -111,7 +111,7 @@ a {
 }
 
 li {
-  padding: 0.4rem 0rem;
+  padding: 0.4rem 0;
 }
 
 .ember-popover {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,3 +1,6 @@
+@import 'vendor/normalize';
+@import 'vendor/html5bp';
+
 @import 'variables';
 @import 'components/code';
 

--- a/tests/dummy/app/styles/components/_code.scss
+++ b/tests/dummy/app/styles/components/_code.scss
@@ -7,7 +7,7 @@ pre code, code {
 }
 
 pre, code {
-  @include rem(border-radius, 0.3);
+  border-radius: 0.3rem;
 
   ::-moz-selection {
     background-color: $black !important;
@@ -21,8 +21,8 @@ pre, code {
 pre,
 .hljs {
   background-color: $darkBlue;
-  @include rem(margin, 3, 0);
-  @include rem(padding, 1.5);
+  margin: 3rem 0rem;
+  padding: 1.5rem;
 }
 
 /**
@@ -30,11 +30,11 @@ Inline code
 */
 
 code {
-  @include rem(padding, 0, 0.4);
-  @include rem(margin, 0, 0.2);
+  padding: 0 0.4rem;
+  margin: 0 0.2rem;
   background-color: rgba($offwhite, 0.5);
   border: 1px solid rgba($faintGray, 0.5);
-  @include rem(font-size, 1.4);
+  font-size: 1.4rem;
   color: $body;
 }
 
@@ -43,12 +43,12 @@ Block code
 */
 
 pre {
-  @include rem(padding, 2);
+  padding: 2rem;
   position: relative;
 }
 
 pre code {
-  @include rem(font-size, 1.5);
+  font-size: 1.5rem;
   background-color: transparent;
   padding: 0;
   margin: 0;
@@ -61,11 +61,10 @@ pre code {
   &:after {
     color: $offwhite;
     background-color: darken($darkBlue, 5%);
-    // font-family: $lato;
     letter-spacing: 0.1;
     text-transform: uppercase;
-    @include rem(font-size, 1.2);
-    @include rem(padding, 0.5, 1);
+    font-size: 1.2rem;
+    padding: 0.5rem 1rem;
     display: inline-block;
     margin: 0;
 
@@ -74,8 +73,8 @@ pre code {
     right: 0;
 
     border: 1px solid rgba($black, 0.3);
-    @include rem(border-bottom-left-radius, 0.3);
-    @include rem(border-bottom-right-radius, 0.3);
+    border-bottom-left-radius: 0.3rem;
+    border-bottom-right-radius: 0.3rem;
   }
 }
 

--- a/tests/dummy/app/styles/vendor/_html5bp.scss
+++ b/tests/dummy/app/styles/vendor/_html5bp.scss
@@ -1,0 +1,245 @@
+/*! HTML5 Boilerplate v5.2.0 | MIT License | https://html5boilerplate.com/ */
+
+/*
+* What follows is the result of much research on cross-browser styling.
+* Credit left inline and big thanks to Nicolas Gallagher, Jonathan Neal,
+* Kroc Camen, and the H5BP dev community and team.
+*/
+
+/* ==========================================================================
+ Base styles: opinionated defaults
+ ========================================================================== */
+
+html {
+  color: #222;
+  font-size: 1em;
+  line-height: 1.4;
+}
+
+/*
+* Remove text-shadow in selection highlight:
+* https://twitter.com/miketaylr/status/12228805301
+*
+* These selection rule sets have to be separate.
+* Customize the background color to match your design.
+*/
+
+::-moz-selection {
+  background: #b3d4fc;
+  text-shadow: none;
+}
+
+::selection {
+  background: #b3d4fc;
+  text-shadow: none;
+}
+
+/*
+* A better looking default horizontal rule
+*/
+
+hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #ccc;
+  margin: 1em 0;
+  padding: 0;
+}
+
+/*
+* Remove the gap between audio, canvas, iframes,
+* images, videos and the bottom of their containers:
+* https://github.com/h5bp/html5-boilerplate/issues/440
+*/
+
+audio,
+canvas,
+iframe,
+img,
+svg,
+video {
+  vertical-align: middle;
+}
+
+/*
+* Remove default fieldset styles.
+*/
+
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+* Allow only vertical resizing of textareas.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/* ==========================================================================
+ Browser Upgrade Prompt
+ ========================================================================== */
+
+.browserupgrade {
+  margin: 0.2em 0;
+  background: #ccc;
+  color: #000;
+  padding: 0.2em 0;
+}
+
+/* ==========================================================================
+ Helper classes
+ ========================================================================== */
+
+/*
+* Hide visually and from screen readers:
+*/
+
+.hidden {
+  display: none !important;
+}
+
+/*
+* Hide only visually, but have it available for screen readers:
+* http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+*/
+
+.visuallyhidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+/*
+* Extends the .visuallyhidden class to allow the element
+* to be focusable when navigated to via the keyboard:
+* https://www.drupal.org/node/897638
+*/
+
+.visuallyhidden.focusable:active,
+.visuallyhidden.focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto;
+}
+
+/*
+* Hide visually and from screen readers, but maintain layout
+*/
+
+.invisible {
+  visibility: hidden;
+}
+
+/*
+* Clearfix: contain floats
+*
+* For modern browsers
+* 1. The space content is one way to avoid an Opera bug when the
+*    `contenteditable` attribute is included anywhere else in the document.
+*    Otherwise it causes space to appear at the top and bottom of elements
+*    that receive the `clearfix` class.
+* 2. The use of `table` rather than `block` is only necessary if using
+*    `:before` to contain the top-margins of child elements.
+*/
+
+.clearfix:before,
+.clearfix:after {
+  content: " "; /* 1 */
+  display: table; /* 2 */
+}
+
+.clearfix:after {
+  clear: both;
+}
+
+/* ==========================================================================
+ Print styles.
+ Inlined to avoid the additional HTTP request:
+ http://www.phpied.com/delay-loading-your-print-css/
+ ========================================================================== */
+
+@media print {
+  *,
+  *:before,
+  *:after,
+  *:first-letter,
+  *:first-line {
+    background: transparent !important;
+    color: #000 !important; /* Black prints faster:
+                               http://www.sanbeiji.com/archives/953 */
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+
+  /*
+   * Don't show links that are fragment identifiers,
+   * or use the `javascript:` pseudo protocol
+   */
+
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+
+  /*
+   * Printing Tables:
+   * http://css-discuss.incutio.com/wiki/Printing_Tables
+   */
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+}

--- a/tests/dummy/app/styles/vendor/_normalize.scss
+++ b/tests/dummy/app/styles/vendor/_normalize.scss
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}


### PR DESCRIPTION
This PR removes the dependency on the `compass-boilerplate` library, which was causing this addon's test suite to fail. Whilst the `compass-boilerplate` test suite was able to be fixed to a passing state, various environments upgrading their node versions have appear to bring incompatibilities causing consuming app's test suites to fail. Specifically, the following error appeared in Ember CLI and Travis builds of this addon:

```
Error: File to import not found or unreadable: node_modules/compass-mixins/lib/compass.
```

By removing `compass-boilerplate` from this project, the test suite is restored to a passing build.

The outputted CSS of the dummy app, which was what we used `compass-boilerplate` for, is styled the same. We're just writing the `scss` in a more explicit way.