### PR TITLE
WIP: absolute parent fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,28 @@
 module.exports = {
   name: 'ember-tooltips',
 
+  config: function(env, baseConfig) {
+    var rootElement = baseConfig.APP.rootElement;
+    var config = {};
+
+    if (rootElement) {
+
+      /*
+      This config overrides tether's bodyElement option.
+
+      https://github.com/HubSpot/tether/blob/4de1f5cb421e0e6149269a347ee261b06bdbd139/src/js/tether.js#L762
+      */
+
+      config['ember-tether'] = {
+        bodyElementId: rootElement.replace('#', ''),
+      };
+    }
+
+    return config;
+  },
+
   included: function(app) {
     this._super.included(app); // For ember-cli-sass
-  }
+  },
 
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-tether": "0.3.1",
+    "ember-tether": "0.4.1",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-netguru-ember": "^1.6.5",
     "loader.js": "^4.0.1"
@@ -58,10 +58,11 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.0",
     "ember-cli-sass": "6.0.0",
-    "ember-hash-helper-polyfill": "^0.1.1"
+    "ember-hash-helper-polyfill": "^0.1.1",
+    "ember-getowner-polyfill": "1.2.2"
   },
   "peerDependencies": {
-    "ember-tether": "0.3.1"
+    "ember-tether": "0.4.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/test-support/helpers/ember-tooltips.js
+++ b/test-support/helpers/ember-tooltips.js
@@ -57,6 +57,8 @@ function getTooltipFromBody(selector=tooltipOrPopoverSelector) {
 
   if (!$tooltip.hasClass('ember-tooltip') && !$tooltip.hasClass('ember-popover')) {
     throw Error(`getTooltipFromBody(): returned an element that is not a tooltip`);
+  } else if ($tooltip.length === 0) {
+    throw Error('getTooltipFromBody(): No tooltips were found.');
   } else if ($tooltip.length > 1) {
     throw Error('getTooltipFromBody(): Multiple tooltips were found. Please provide an {option.selector = ".specific-tooltip-class"}');
   }
@@ -68,7 +70,9 @@ function getTooltipTargetFromBody(selector = tooltipOrPopoverTargetSelector) {
   const $body = $(document.body);
   const $tooltipTarget = $body.find(selector) ;
 
-  if ($tooltipTarget.length > 1) {
+  if ($tooltipTarget.length === 0) {
+    throw Error('getTooltipTargetFromBody(): No tooltip targets were found.');
+  } else if ($tooltipTarget.length > 1) {
     throw Error('getTooltipTargetFromBody(): Multiple tooltip targets were found. Please provide an {option.targetSelector = ".specific-tooltip-target-class"}');
   }
 
@@ -101,9 +105,9 @@ function validateSide(side, testHelper = 'assertTooltipSide') {
 }
 
 function getTooltipAndTargetPosition(options = {}) {
-  const $target = getTooltipTargetFromBody(options.targetSelector);
+  const $target = getTooltipTargetFromBody(options.targetSelector || tooltipOrPopoverTargetSelector);
   const targetPosition = $target[0].getBoundingClientRect();
-  const $tooltip = getTooltipFromBody(options.selector);
+  const $tooltip = getTooltipFromBody(options.selector || tooltipOrPopoverSelector);
   const tooltipPosition = $tooltip[0].getBoundingClientRect();
 
   return {
@@ -112,10 +116,17 @@ function getTooltipAndTargetPosition(options = {}) {
   };
 }
 
-/* TODO(Duncan):
+/* TODO(Duncan): Document */
 
-Update triggerTooltipTargetEvent() to use getTooltipTargetFromBody
-and move side into the options hash */
+export function findTooltip(selector = tooltipOrPopoverSelector) {
+  return getTooltipFromBody(selector);
+}
+
+/* TODO(Duncan): Document */
+
+export function findTooltipTarget(selector = tooltipOrPopoverTargetSelector) {
+  return getTooltipTargetFromBody(selector);
+}
 
 export function triggerTooltipTargetEvent($element, type, options={}) {
 
@@ -128,7 +139,7 @@ export function triggerTooltipTargetEvent($element, type, options={}) {
   let wasEventTriggered = false;
 
   if (options.selector) {
-    $element = $element.find(options.selector);
+    $element = getTooltipTargetFromBody(options.selector);
   }
 
   // we need to need to wrap any code with asynchronous side-effects in a run
@@ -139,6 +150,7 @@ export function triggerTooltipTargetEvent($element, type, options={}) {
       return;
     }
     if (type === 'focus' || type === 'blur') {
+
       // we don't know why but this is necessary when type is 'focus' or 'blur'
       $element[0].dispatchEvent(new window.Event(type));
     } else {

--- a/tests/integration/components/effect-test.js
+++ b/tests/integration/components/effect-test.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
+const { $ } = Ember;
 
 moduleForComponent('tooltip-on-element', 'Integration | Component | tooltip on element', {
   integration: true,
@@ -11,7 +14,7 @@ moduleForComponent('tooltip-on-element', 'Integration | Component | tooltip on e
     this.set('effectType', effectType);
     this.render(hbs`{{tooltip-on-element effect=effectType}}`);
 
-    const $tooltip = this.$().find('.ember-tooltip');
+    const $tooltip = $('.ember-tooltip');
 
     assert.ok($tooltip.hasClass(`ember-tooltip-or-popover-${effectType}`),
         `the tooltip should have the ${effectType} effect class`);

--- a/tests/integration/components/pass-through-test.js
+++ b/tests/integration/components/pass-through-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { findTooltip } from 'dummy/tests/helpers/ember-tooltips';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('tooltip-on-element', 'Integration | Component | pass through properties', {
@@ -23,7 +24,7 @@ test('tooltip-on-element pass through attributes test', function(assert) {
     }}
   `);
 
-  const $tooltip = this.$().find('.ember-tooltip');
+  const $tooltip = findTooltip();
 
   /* Assert that the attributes are passed from
   the lazy-render-wrapper component to the $tooltip

--- a/tests/integration/components/popover/attachment-test.js
+++ b/tests/integration/components/popover/attachment-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { findTooltip } from 'dummy/tests/helpers/ember-tooltips';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('popover-on-element', 'Integration | Component | popover on element', {
@@ -12,7 +13,7 @@ test('attachment and targetAttachment override test', function(assert) {
   this.render(hbs`{{popover-on-element targetAttachment='top right' attachment='top left' keepInWindow=false}}`);
 
   const $target = this.$();
-  const $popover = $target.find('.ember-popover');
+  const $popover = findTooltip();
 
   const classPrefix = 'ember-tooltip-or-popover';
   const targetClassPrefix =  `${classPrefix}-target-attached`;

--- a/tests/integration/components/popover/event-bubbling-test.js
+++ b/tests/integration/components/popover/event-bubbling-test.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import {
+  assertTooltipNotVisible,
+  assertTooltipRendered,
+  triggerTooltipTargetEvent,
+} from '../../../helpers/ember-tooltips';
+import hbs from 'htmlbars-inline-precompile';
+
+const { $ } = Ember;
+
+moduleForComponent('popover-on-element', 'Integration | Option | Event bubbling', {
+  integration: true,
+});
+
+/* This module tests whether actions not related to popovers
+can be bubbled from inside the popover.
+
+This is testing the ember-tether config applied by this addon.
+
+https://github.com/sir-dunxalot/ember-tooltips/commit/e2e39db2868422b6c2484fe35e9951418f06d8a0#diff-168726dbe96b3ce427e7fedce31bb0bcR7
+
+This fixes issues like the following:
+
+- https://github.com/sir-dunxalot/ember-tooltips/issues/141
+- https://github.com/sir-dunxalot/ember-tooltips/issues/157
+
+In this test, we put a button in the popover that is expected to send
+an action to the test's context when the button is clicked.
+The test will pass when the action sent from inside the
+popover is captured by the context of the test.
+*/
+
+test('Popover: bubble click event', function(assert) {
+
+  assert.expect(4);
+
+  this.on('testaction', function() {
+
+    /* The testaction action is fired when the
+    button is clicked */
+
+    assert.ok(true,
+      'The eventhandler should be fired');
+
+  });
+
+  this.render(hbs`
+    {{#some-component}}
+      {{#popover-on-component}}
+        <button class="test-button-with-action" {{action 'testaction'}}>test button</button>
+      {{/popover-on-component}}
+    {{/some-component}}
+  `);
+
+  const $button = $('.test-button-with-action');
+  const $target = $('.some-component');
+
+  assertTooltipNotVisible(assert);
+  triggerTooltipTargetEvent($target, 'mouseenter');
+  assertTooltipRendered(assert);
+
+  assert.equal($button.length, 1, 'the button can be found');
+
+  /* Click the button to fire testaction. This will
+  call the final assertion and the test will end. */
+
+  $button.trigger('click');
+
+});

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -1,19 +1,25 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipSide } from '../../helpers/ember-tooltips';
+import { assertTooltipSide } from 'dummy/tests/helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | side and keepInWindow', {
   integration: true,
 });
 
 /* Test the positions without forcing the tooltip
-to stay in the window. */
+to stay in the window.
+
+It's necessary to use effect='none' because the `effect` class causes
+spacing to be incorrect. The default `'fade'` effect moves about `10px`
+closer to the target prior to the tooltip being animated when the
+tooltip is shown.
+*/
 
 test('tooltip-on-element shows on the top by default', function(assert) {
 
   assert.expect(1);
 
-  this.render(hbs`{{tooltip-on-element keepInWindow=false}}`);
+  this.render(hbs`{{tooltip-on-element keepInWindow=false effect='none'}}`);
 
   assertTooltipSide(assert, { side: 'top' });
 
@@ -23,7 +29,7 @@ test('tooltip-on-element shows on the top', function(assert) {
 
   assert.expect(1);
 
-  this.render(hbs`{{tooltip-on-element side='top' keepInWindow=false}}`);
+  this.render(hbs`{{tooltip-on-element side='top' keepInWindow=false effect='none'}}`);
 
   assertTooltipSide(assert, { side: 'top' });
 
@@ -33,7 +39,7 @@ test('tooltip-on-element shows with showOn right', function(assert) {
 
   assert.expect(1);
 
-  this.render(hbs`{{tooltip-on-element side='right' keepInWindow=false}}`);
+  this.render(hbs`{{tooltip-on-element side='right' keepInWindow=false effect='none'}}`);
 
   assertTooltipSide(assert, { side: 'right' });
 
@@ -43,7 +49,7 @@ test('tooltip-on-element shows with showOn bottom', function(assert) {
 
   assert.expect(1);
 
-  this.render(hbs`{{tooltip-on-element side='bottom' keepInWindow=false}}`);
+  this.render(hbs`{{tooltip-on-element side='bottom' keepInWindow=false effect='none'}}`);
 
   assertTooltipSide(assert, { side: 'bottom' });
 
@@ -53,7 +59,7 @@ test('tooltip-on-element shows with showOn left', function(assert) {
 
   assert.expect(1);
 
-  this.render(hbs`{{tooltip-on-element side='left' keepInWindow=false}}`);
+  this.render(hbs`{{tooltip-on-element side='left' keepInWindow=false effect='none'}}`);
 
   assertTooltipSide(assert, { side: 'left' });
 

--- a/tests/integration/components/spacing-test.js
+++ b/tests/integration/components/spacing-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import { assertTooltipSpacing } from 'dummy/tests/helpers/ember-tooltips';
 import hbs from 'htmlbars-inline-precompile';
-import { assertTooltipSpacing } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Option | spacing', {
   integration: true,
@@ -12,7 +12,7 @@ test('tooltip-on-element shows with spacing=default', function(assert) {
 
   /* Check the default spacing */
 
-  this.render(hbs`{{tooltip-on-element}}`);
+  this.render(hbs`{{tooltip-on-element effect='none'}}`);
 
   assertTooltipSpacing(assert, {
     side: 'top',
@@ -27,7 +27,7 @@ test('tooltip-on-element shows with spacing=20', function(assert) {
 
   /* Check custom spacing */
 
-  this.render(hbs`{{tooltip-on-element spacing=20}}`);
+  this.render(hbs`{{tooltip-on-element spacing=20 effect='none'}}`);
 
   assertTooltipSpacing(assert, {
     side: 'top',
@@ -44,6 +44,7 @@ test('tooltip-on-element shows with spacing=20 and side=right', function(assert)
 
   this.render(hbs`
     {{tooltip-on-element
+       effect='none'
       spacing=20
       side='right'
       keepInWindow=false
@@ -65,6 +66,7 @@ test('tooltip-on-element shows with spacing=53 and side=bottom', function(assert
 
   this.render(hbs`
     {{tooltip-on-element
+      effect='none'
       spacing=53
       side='bottom'
       keepInWindow=false

--- a/tests/integration/components/tether/is-element-test.js
+++ b/tests/integration/components/tether/is-element-test.js
@@ -1,10 +1,14 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { findTooltip, findTooltipTarget } from 'dummy/tests/helpers/ember-tooltips';
 import {
   isElementInPopover,
   isElementInTargetAndNotInPopover,
   isElementElsewhere,
 } from 'ember-tooltips/components/tether-popover-on-element';
+
+const { $ } = Ember;
 
 let $elsewhere;
 let $parentElsewhere;
@@ -29,12 +33,12 @@ moduleForComponent('tether-popover-on-element', 'Integration | Utility | isEleme
       </div>
     `);
 
-    $target = this.$('.target');
-    $targetInterior = this.$('.target-interior');
-    $popover = this.$('.ember-popover');
-    $popoverInterior = this.$('.popover-interior');
-    $elsewhere = this.$('.elsewhere');
-    $parentElsewhere = this.$('.parent-elsewhere');
+    $target = findTooltipTarget();
+    $targetInterior = $('.target-interior');
+    $popover = findTooltip();
+    $popoverInterior = $('.popover-interior');
+    $elsewhere = $('.elsewhere');
+    $parentElsewhere = $('.parent-elsewhere');
   },
 });
 

--- a/tests/integration/components/tooltip-on-element-test.js
+++ b/tests/integration/components/tooltip-on-element-test.js
@@ -1,7 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import { assertTooltipRendered } from '../../helpers/ember-tooltips';
+import { assertTooltipRendered, findTooltipTarget } from 'dummy/tests/helpers/ember-tooltips';
 import hbs from 'htmlbars-inline-precompile';
-
 import { assertTooltipContent } from '../../helpers/ember-tooltips';
 
 moduleForComponent('tooltip-on-element', 'Integration | Component | tooltip on element', {
@@ -39,7 +38,7 @@ test('tooltip-on-element has the proper aria-describedby tag', function(assert) 
     </div>
   `);
 
-  const $tooltipTarget = this.$('.target');
+  const $tooltipTarget = findTooltipTarget();
   const describedBy = $tooltipTarget.attr('aria-describedby');
 
   assertTooltipContent(assert, {

--- a/tests/integration/config/body-element-id-test.js
+++ b/tests/integration/config/body-element-id-test.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+const { $ } = Ember;
+
+moduleForComponent('tooltip-on-element', 'Integration | Config | body-element-id', {
+  integration: true,
+});
+
+test('Tooltip is rendered on rootElement not body', function(assert) {
+
+  assert.expect(2);
+
+  this.render(hbs`{{tooltip-on-element}}`);
+
+  const $tooltip = $(document.body).find('.ember-tooltip');
+  const $tooltipParent = $tooltip.parent();
+  const tooltipParentId = $tooltipParent.attr('id');
+
+  assert.notEqual($tooltipParent.attr('tagname'), 'body',
+    'The tooltip should not be a child of the document body');
+
+  assert.equal(tooltipParentId, 'ember-testing',
+    'The tooltip should be a child of the #ember-testing rootElement');
+
+});


### PR DESCRIPTION
Opening for discussion—**NOT READY TO BE MERGED**

This PR is like https://github.com/sir-dunxalot/ember-tooltips/pull/162 with the following differences:

- ember-tether upgraded to 0.4.1
- rebased on master
- [this change](https://github.com/sir-dunxalot/ember-tooltips/commit/3d909cfd73b5f39c958026929b8eb348a536db29#diff-69f16599a8e1e70e9e2cbef7f505b706) reverted
- scenario for Ember 1.13 added back in
- commits squashed into a temporary "dash commit" for now

The good news is that the tests are passing in Ember 1.13.

The bad news is that the tests are now failing in Glimmer 2. I believe this is another upstream issue with ember-tether. I'm gonna switch gears for now and look into that. I'll post my findings back here.