### PR TITLE
Fixes issue where toggle is called after show which hides the tooltip…

### DIFF
--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -317,6 +317,12 @@ export default EmberTetherComponent.extend({
     this._super(...arguments);
 
     if (this.get('_shouldShowOnRender')) {
+
+      /* When using enableLazyRendering the focus event occurs before the click event.
+        When this happens we don't want to call focus then click.
+        _isInProcessOfShowing prevents that from happening. */
+
+      this.set('_isInProcessOfShowing', true);
       this.show();
     }
 


### PR DESCRIPTION
…/popver.

Sets _isInProcessOfShowing from `didInsertElement` before showing.