### PR TITLE
make sure tooltips stay in window

### DIFF
--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -181,6 +181,7 @@ export default EmberTetherComponent.extend({
         {
           to: 'window',
           attachment: 'together',
+          pin: true,
         },
       ];
     }


### PR DESCRIPTION
Partially addresses #72

Prevents tooltips from being cut off if they are near a border of the viewport. Grep for "pin" [here](http://tether.io/) for explanation of the pin option.