### PR TITLE
move ember-tether to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "6.0.0",
-    "ember-hash-helper-polyfill": "^0.1.1"
+    "ember-hash-helper-polyfill": "^0.1.1",
+    "ember-tether": "^0.4.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",
@@ -54,7 +55,6 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "^2.11.0",
-    "ember-tether": "^0.4.1",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-netguru-ember": "^1.6.5",
     "loader.js": "^4.0.10"


### PR DESCRIPTION
## Fix for issue [#165](https://github.com/sir-dunxalot/ember-tooltips/issues/165)

Ember-tether is needed for this addon, but it will not be installed when you do a fresh install and don't have the dependency installed in your local project.
Moving it from `devDependencies` to `dependencies` should make sure it's installed.