### PR TITLE
Add `isDisabled` property to tooltips, allowing them to be disabled

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -42,6 +42,7 @@ const PASSABLE_PROPERTIES = [
   'side',
   'showOn',
   'spacing',
+  'isDisabled',
   'isShown',
   'tooltipIsVisible',
   'hideDelay',
@@ -168,16 +169,16 @@ export default Component.extend({
     return $target;
   }),
 
-  _shouldRender: computed('isShown', 'tooltipIsVisible', 'enableLazyRendering', '_hasUserInteracted', function() {
+  _shouldRender: computed('isDisabled', 'isShown', 'tooltipIsVisible', 'enableLazyRendering', '_hasUserInteracted', function() {
 
-    /* If isShown, tooltipIsVisible, !enableLazyRendering, or _hasUserInteracted then
+    /* If isDisabled, isShown, tooltipIsVisible, !enableLazyRendering, or _hasUserInteracted then
     we return true and set _hasRendered to true because
     there is never a scenario where this wrapper should destroy the tooltip
     */
 
     if (this.get('_hasRendered')) {
       return true;
-    } else if (this.get('isShown') || this.get('tooltipIsVisible')) {
+    } else if (!this.get('isDisabled') && (this.get('isShown') || this.get('tooltipIsVisible'))) {
 
       this.set('_hasRendered', true);
 
@@ -187,7 +188,7 @@ export default Component.extend({
       this.set('_hasRendered', true);
 
       return true;
-    } else if (this.get('_hasUserInteracted')) {
+    } else if (!this.get('isDisabled') && this.get('_hasUserInteracted')) {
 
       this.set('_hasRendered', true);
 

--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -58,6 +58,7 @@ export default EmberTetherComponent.extend({
   showOn: null,
   spacing: 10,
   tabindex: '0', // A positive integer (to enable) or -1 (to disable)
+  isDisabled: false,
   isShown: false,
   tooltipIsVisible: computed.deprecatingAlias('isShown', {
     id: 'tooltip-and-popover.tooltipIsVisible',
@@ -442,7 +443,7 @@ export default EmberTetherComponent.extend({
 
     this.positionTether();
 
-    if (this.get('isDestroying')) {
+    if (this.get('isDisabled') || this.get('isDestroying')) {
       return;
     }
 


### PR DESCRIPTION
Usage:

```
<button>
  Click me
  {{#tooltip-on-element isDisabled=true}}
    I'm a popup but you can't see me
  {{/tooltip-on-element}}
</button>
```

If there's interest in merging this, I can add tests as needed to get it up to par.