### PR TITLE
Wrap jquery event handlers in Ember.run

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -9,6 +9,7 @@ const {
   get,
   isNone,
   warn,
+  run
 } = Ember;
 
 export const TARGET_EVENT_NAMESPACE = 'target-lazy-render-wrapper';
@@ -247,13 +248,13 @@ export default Component.extend({
       if the user has mouseenter and not mouseleave immediately afterwards.
       */
 
-      $target.on(`mouseleave.${TARGET_EVENT_NAMESPACE}`, () => {
+      $target.on(`mouseleave.${TARGET_EVENT_NAMESPACE}`, run.bind(this, function() {
         this.set('_shouldShowOnRender', false);
-      });
+      }));
     }
 
     this.get('_lazyRenderEvents').forEach((_lazyRenderEvent) => {
-      $target.on(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`, () => {
+      $target.on(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`, run.bind(this, function() {
         if (this.get('_hasUserInteracted')) {
           $target.off(`${_lazyRenderEvent}.${TARGET_EVENT_NAMESPACE}`);
         } else {
@@ -261,7 +262,7 @@ export default Component.extend({
           this.set('_shouldShowOnRender', true);
           this.set('_isInProcessOfShowing', true);
         }
-      });
+      }));
     });
   },
 

--- a/addon/components/tether-popover-on-element.js
+++ b/addon/components/tether-popover-on-element.js
@@ -115,9 +115,9 @@ export default TooltipAndPopoverComponent.extend({
       const _showOn = this.get('_showOn');
       const _hideOn = this.get('_hideOn');
 
-      $target.on(_showOn, () => this.show());
+      $target.on(_showOn, run.bind(this, function() { this.show() }));
 
-      $target.add($popover).on(_hideOn, () => {
+      $target.add($popover).on(_hideOn, run.bind(this, function() { 
         this.set('_isMouseInside', false);
 
         const hideDelay = +this.get('hideDelay');
@@ -134,17 +134,17 @@ export default TooltipAndPopoverComponent.extend({
         } else {
           hideIfOutside();
         }
-      });
+      }));
 
       /* We must use mouseover because it correctly
       registers hover interactivity when spacing='0'
       */
 
-      $target.add($popover).on('mouseover', () => this.set('_isMouseInside', true));
+      $target.add($popover).on('mouseover', run.bind(this, function() { this.set('_isMouseInside', true) }));
 
     } else if (event === 'click') {
 
-      $(document).on(`click.${target}`, (event) => {
+      $(document).on(`click.${target}`, run.bind(this, function(event) {
 
         /* This lightweight, name-spaced click handler is
         necessary to determine where a click occurs
@@ -173,10 +173,10 @@ export default TooltipAndPopoverComponent.extend({
             this.toggle();
           }
         }
-      });
+      }));
     }
 
-    $target.on('focus', () => {
+    $target.on('focus', run.bind(this, function() {
 
       /* The focus event occurs before the click event.
       when this happens we don't want to call focus then click.
@@ -185,9 +185,9 @@ export default TooltipAndPopoverComponent.extend({
 
       this.set('_isInProcessOfShowing', true);
       this.show();
-    });
+    }));
 
-    $target.add($popover).on('focusout', () => {
+    $target.add($popover).on('focusout', run.bind(this, function() {
 
       /* Use a run.later() to allow the 'focusout' event
       to finish handling.
@@ -200,7 +200,7 @@ export default TooltipAndPopoverComponent.extend({
           this.hide();
         }
       });
-    });
+    }));
   },
   willDestroyElement() {
     this._super(...arguments);

--- a/addon/components/tether-tooltip-on-element.js
+++ b/addon/components/tether-tooltip-on-element.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import TooltipAndPopoverComponent from 'ember-tooltips/components/tether-tooltip-and-popover';
 
-const { $ } = Ember;
+const { $, run } = Ember;
 
 export default TooltipAndPopoverComponent.extend({
 
@@ -24,7 +24,7 @@ export default TooltipAndPopoverComponent.extend({
       the visibility */
 
       if (_showOn === _hideOn) {
-        $target.on(_showOn, () => {
+        $target.on(_showOn, run.bind(this, function() {
 
           /* When using enableLazyRendering the focus event occurs before the click event.
           When this happens we don't want to call focus then click.
@@ -35,21 +35,21 @@ export default TooltipAndPopoverComponent.extend({
           } else {
             this.toggle();
           }
-        });
+        }));
       } else {
 
         /* Else, add the show and hide events individually */
 
         if (_showOn !== 'none') {
-          $target.on(_showOn, () => {
+          $target.on(_showOn, run.bind(this, function() {
             this.show();
-          });
+          }));
         }
 
         if (_hideOn !== 'none') {
-          $target.on(_hideOn, () => {
+          $target.on(_hideOn, run.bind(this, function() {
             this.hide();
-          });
+          }));
         }
       }
 


### PR DESCRIPTION
Without this, sometimes our application's tests will fail with this error:

> Assertion Failed: You have turned on testing mode, which disabled the run-loop's autorun. You will need to wrap any code with asynchronous side-effects in a run.