### PR TITLE
Bump ember-tether

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^7.0.0",
     "ember-hash-helper-polyfill": "^0.1.1",
-    "ember-tether": "^0.4.1"
+    "ember-tether": "^1.0.0-beta.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",


### PR DESCRIPTION
Ember-tether 1.0.0 has been tested for 4 months already, I think we can safely update.

Also, this was making `ember-cli-dependency-lint` complain as I have other addons that have updated.

Something to take into account  is that Ember 2.3 is not supported by this new version, IDK if this can be a problem. 2.4LTS, 2.8LTS and 2.12TLS seem enough backwards compatibility for me, but it's something