### PR TITLE
Add optional setPin parameter to enhance keepInWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 - [event](#event)
 - [hideOn](#hide-on)
 - [keepInWindow](#keep-in-window)
+- [setPin](#set-pin)
 - [side](#side)
 - [showOn](#show-on)
 - [spacing](#spacing)
@@ -299,6 +300,23 @@ it will render off-screen--}}
 {{tooltip-on-component
   keepInWindow=false
   side='right'
+}}
+```
+
+#### Set pin
+
+| Type    | Boolean   |
+|---------|-----------|
+| Default | undefined |
+
+If you find that `keepInWindow` is not keeping the entire tooltip in the window, try also using `setPin`. Note that this is somewhat experimental, and may not work for all window positioning issues (see #72).
+
+```hbs
+{{!--Force the tooltip to stay fully in-screen--}}
+
+{{tooltip-on-component
+  keepInWindow=true
+  setPin=true
 }}
 ```
 

--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -39,6 +39,7 @@ const PASSABLE_PROPERTIES = [
   'event',
   'hideOn',
   'keepInWindow',
+  'setPin',
   'side',
   'showOn',
   'spacing',

--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -173,7 +173,7 @@ export default EmberTetherComponent.extend({
     return `${verticalPosition} ${horizontalPosition}`;
   }),
 
-  constraints: computed('keepInWindow', function() {
+  constraints: computed('keepInWindow', 'setPin', function() {
     let constraints;
 
     if (this.get('keepInWindow')) {
@@ -181,6 +181,7 @@ export default EmberTetherComponent.extend({
         {
           to: 'window',
           attachment: 'together',
+          pin: this.get('setPin'),
         },
       ];
     }


### PR DESCRIPTION
This resolves issue #72 while also not changing anything for existing users.  There is now an _optional_ `setPin` parameter that users can set along with `keepInWindow` to help keep the entire tooltip in window.

(_Thank you @kybishop for finding a good solution_)

## Testing

I have done manual testing inside my application using this commit to confirm the following: 

1. Using `setPin` with `keepInWindow` does make it so the entire tooltip stays in window, which resolves #72 for us:
```
{{#popover-on-component
  keepInWindow=true
  setPin=true
}}
```
2. Setting `setPin=false` and omitting `setPin` entirely appears to have no effect on the current use of `ember-tooltips` (i.e. nothing breaks!)
