### PR TITLE
Update ember-hash-helper-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^7.0.0",
-    "ember-hash-helper-polyfill": "^0.1.1",
+    "ember-hash-helper-polyfill": "^0.2.0",
     "ember-tether": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This update bumps the minimum node version to v4 and bumps
ember-cli-babel to v6.8.2 neither of which should have any adverse effect on ember-tooltips.