### PR TITLE
Fix events listeners removal on Destroy

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -535,9 +535,7 @@ export default Component.extend({
     /* Add the event listeners */
 
     run(() => {
-      target.addEventListener(eventName, (event) => {
-        callback(event);
-      });
+      target.addEventListener(eventName, callback);
     });
   },
 


### PR DESCRIPTION
In the `_tooltipEvents` property, the callback is registered (to be able to remove listeners later). But the callback is wrapped when added to the target. So, the removal won't work onDestroy.
We should either remove the wrapper or register it in properly in the `_tooltipEvents` list.