### PR TITLE
Prevents Fastboot error in willDestroy hook

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -188,6 +188,12 @@ export default Component.extend({
 
   willDestroy() {
     this._super(...arguments);
+    const tooltip = this.get('_tooltip');
+
+    if (!tooltip) {
+      return;
+    }
+
     this.hide();
 
     const _tooltipEvents = this.get('_tooltipEvents');


### PR DESCRIPTION
This PR fixes the Fastboot error detailed below inside the `willDestroy` hook.

```
There was an error running your app in fastboot. More info about the error:
 TypeError: Cannot read property 'dispose' of null
    at Class.willDestroy (/Users/will/Code/themarshalsgroup-riskmap/tmp/broccoli_persistent_filterautoprefixer_filter-output_path-6YxFbSBF.tmp/assets/addon-tree-output/ember-tooltips/components/ember-tooltip-base.js:205:1)
```

It simply checks for the presence of a tooltip before running any teardown functions.