### PR TITLE
[3.0 beta] Call `setSpacing()` on popper.js create instead of update

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -333,6 +333,7 @@ export default Component.extend({
                   /* Once the wormhole has done it's work, we need the tooltip to be positioned again */
 
                   run.scheduleOnce('afterRender', () => {
+                    this.setSpacing();
                     const popperInstance = tooltipData.instance;
 
                     popperInstance.state.updateBound();
@@ -340,10 +341,6 @@ export default Component.extend({
 
                   resolve(tooltipData);
                 });
-              },
-
-              onUpdate: () => {
-                this.setSpacing();
               },
             },
           });
@@ -380,8 +377,6 @@ export default Component.extend({
     style.marginLeft = 0;
 
     popper.style[`margin${capitalize(marginSide)}`] = `${this.get('spacing')}px`;
-
-    popperInstance.state.updateBound();
   },
 
   hide() {


### PR DESCRIPTION
`popperInstance.state.updateBound();` triggers `onUpdate()` which leads to an endless loop and 100% cpu utilization.