### PR TITLE
Fix FastBoot compatibility

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -267,6 +267,7 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
+    if (typeof FastBoot !== 'undefined') return;
 
     const $target = this.get('$target');
 

--- a/addon/components/tether-popover-on-element.js
+++ b/addon/components/tether-popover-on-element.js
@@ -204,6 +204,8 @@ export default TooltipAndPopoverComponent.extend({
   },
   willDestroyElement() {
     this._super(...arguments);
+    // Avoid any problems in FastBoot by returning early
+    if (this.get('isFastBoot')) return;
 
     const target = this.get('target');
     const $target = $(target);

--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -205,17 +205,15 @@ export default EmberTetherComponent.extend({
     return side === 'top' || side === 'bottom';
   }),
 
+  isFastBoot: computed(function() {
+    return typeof FastBoot !== 'undefined';
+  }),
+
   target: computed(function() {
+    // It's not possible to access the DOM when running in Fastboot
+    if (this.get('isFastBoot')) return null;
+
     const $element = this.$();
-
-    /* It's not possible to access the DOM when
-    running in Fastboot
-    */
-
-    if (!$element) {
-      return null;
-    }
-
     const parentElement = $element.parent();
     let parentElementId = parentElement && parentElement.attr('id');
 
@@ -500,15 +498,11 @@ export default EmberTetherComponent.extend({
   },
 
   willDestroy() {
-
-    /* There's no jQuery when running in Fastboot */
-
-    const $target = $ && $(this.get('target'));
-
     this.set('effect', null);
     this.hide();
 
-    if ($target) {
+    if (!this.get('isFastBoot')) {
+      const $target = $(this.get('target'));
       $target.removeAttr('aria-describedby');
       $target.off();
     }


### PR DESCRIPTION
This fixes errors like: 

``` Error: Accessing `this.element` is not allowed in non-interactive environments (such as FastBoot).```