### PR TITLE
Positioning Issue with 3.0.0-beta.2

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -317,6 +317,9 @@ export default Component.extend({
                 flip: {
                   enabled: this.get('enableFlip'),
                 },
+                preventOverflow: {
+                  escapeWithReference: true
+                }
               },
 
               onCreate: (tooltipData) => {


### PR DESCRIPTION
I was having an issue with 3.0.0-beta.2 where if a higher container element had `overflow-y: scroll` and the parent element to the tooltip was `display: flex`, the tooltip would render over the parent element regardless of the positioning I passed into the component.

I recreated an example of this [here](https://mfees.github.io/ember-tooltip-example/example/).

In the modifiers in ember-tooltip-base.js, I added this:
```javascript
preventOverflow: {
   escapeWithReference: true
}
```
This seems to resolve the issue and didn't seem to cause additional issues when overflow and flex are not set on the parents.