### PR TITLE
Update ember-tooltip-base.js

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -208,7 +208,7 @@ export default Component.extend({
 
     run(this.get('_tooltip').dispose);
 
-    if (!this.isDestroyed && !this.isDestroying) {     
+    if (!this.isDestroyed && !this.isDestroying) {
       this.sendAction('onDestroy', this);
     }
   },

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -208,7 +208,9 @@ export default Component.extend({
 
     run(this.get('_tooltip').dispose);
 
-    this.sendAction('onDestroy', this);
+    if (!this.isDestroyed && !this.isDestroying) {     
+      this.sendAction('onDestroy', this);
+    }
   },
 
   addTargetEventListeners() {


### PR DESCRIPTION
don't destroy things which are currently being destroyed or are destroyed.

was erroring when being used in a vertical-collection.