### PR TITLE
fix: ember engine failure at build time

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'ember-tooltips',
 
   config: function(env, baseConfig) {
-    var rootElement = baseConfig.APP.rootElement;
+    var rootElement = baseConfig.APP && baseConfig.APP.rootElement;
     var config = {};
 
     if (rootElement) {


### PR DESCRIPTION
> ember s
...
> Cannot read property 'rootElement' of undefined

Workaround until versioned:

```js
// config/environment.js
/* eslint-env node */
'use strict';

module.exports = function(environment) {
  let ENV = {
    modulePrefix: 'engine-name',
    environment,
    APP: {} // <---
  };

  return ENV;
};
```