### PR TITLE
Fix: Error in Ember 3.0 when onDestroy action is sent

### DIFF
--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -499,14 +499,16 @@ export default EmberTetherComponent.extend({
     }
   },
 
-  willDestroy() {
+  willDestroyElement() {
 
     /* There's no jQuery when running in Fastboot */
 
     const $target = $ && $(this.get('target'));
 
     this.set('effect', null);
-    this.hide();
+    if (this.get('isShown')) {
+      this.hide();
+    }
 
     if ($target) {
       $target.removeAttr('aria-describedby');


### PR DESCRIPTION
Addresses #247 

In Ember 3.0, the `sendAction` method now has an assert in it that checks for `this.isDestroyed` and `this.isDestroying`. The `willDestroy` hook is reached after `this.isDestroying` is set to true. The `hide()` method would just return if `isDestroying` was true, but since we are calling it when it is no longer true, we just check if the element is shown instead. 