### PR TITLE
Fix for glimmer 2 issue

### DIFF
--- a/addon/components/lazy-render-wrapper.js
+++ b/addon/components/lazy-render-wrapper.js
@@ -90,6 +90,9 @@ export default Component.extend({
   _hasUserInteracted: false,
   _hasRendered: false,
   _shouldShowOnRender: false,
+  // Used for Glimmer 2 compatibilty
+  // See https://github.com/yapplabs/ember-wormhole/issues/66#issuecomment-263575168 for more info
+  _shouldTargetGrandparentElement: true,
 
   /* 3. Single line Computed Property */
 

--- a/addon/components/tether-tooltip-and-popover.js
+++ b/addon/components/tether-tooltip-and-popover.js
@@ -214,7 +214,14 @@ export default EmberTetherComponent.extend({
       return null;
     }
 
-    const parentElement = $element.parent();
+    let parentElement = $element.parent();
+
+    if (this.get('_shouldTargetGrandparentElement')) {
+      // Used for Glimmer 2 compatibilty
+      // See https://github.com/yapplabs/ember-wormhole/issues/66#issuecomment-263575168 for more info
+      parentElement = parentElement.parent();
+    }
+
     let parentElementId = parentElement && parentElement.attr('id');
 
     if (!parentElementId) {

--- a/addon/templates/components/lazy-render-wrapper.hbs
+++ b/addon/templates/components/lazy-render-wrapper.hbs
@@ -1,20 +1,23 @@
 {{#if _shouldRender}}
-	{{#component tetherComponentName
-		passedPropertiesObject=passedPropertiesObject
-		class=class
-		id=id
-		classNames=classNames
+  <div>
+  	{{#component tetherComponentName
+  		passedPropertiesObject=passedPropertiesObject
+  		class=class
+  		id=id
+  		classNames=classNames
 
-		_shouldShowOnRender=_shouldShowOnRender
-		_isInProcessOfShowing=_isInProcessOfShowing
-	}}
-    {{#if hasBlock}}
-      {{yield (hash
-        hide=(action "hide")
-      )}}
-    {{else}}
-      {{text}}
-    {{/if}}
-	{{/component}}
+  		_shouldShowOnRender=_shouldShowOnRender
+  		_isInProcessOfShowing=_isInProcessOfShowing
+      _shouldTargetGrandparentElement=_shouldTargetGrandparentElement
+  	}}
+      {{#if hasBlock}}
+        {{yield (hash
+          hide=(action "hide")
+        )}}
+      {{else}}
+        {{text}}
+      {{/if}}
+  	{{/component}}
+  </div>
 {{/if}}
 

--- a/tests/integration/components/unstable-root-test.js
+++ b/tests/integration/components/unstable-root-test.js
@@ -1,0 +1,40 @@
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import {
+  assertTooltipVisible,
+  assertTooltipNotRendered
+} from 'dummy/tests/helpers/ember-tooltips';
+
+moduleForComponent('tooltip-on-element', 'Integration | Component | unstable root', {
+  integration: true,
+});
+
+test('tooltip-on-element does not throw an error when in unstable root element', function(assert) {
+
+  assert.expect(2);
+
+  this.set('showTooltip', true);
+
+  this.render(hbs`
+    {{#if showTooltip}}
+      {{#tooltip-on-element
+        isShown=showTooltip
+      }}
+        Test content
+      {{/tooltip-on-element}}
+    {{/if}}
+  `);
+  
+
+  assertTooltipVisible(assert);
+
+  this.set('showTooltip', false);
+
+  // The Glimmer 2 update would cause the tooltips to break when wrapped by an unstable root element
+  // In this case the {{if}}
+  // An error would be thrown if the tooltip component was not wrapped by a div in the lazy-wrapper template
+  // The error thrown would be: DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
+  // More info: https://github.com/yapplabs/ember-wormhole/issues/66
+  assertTooltipNotRendered(assert);
+
+});


### PR DESCRIPTION
This actually builds upon this open PR : https://github.com/sir-dunxalot/ember-tooltips/pull/176. 

I just added what was suggested. If you are using the wrapper, the target is the grandparent element. If you are not using it, it will still be the same code as before. This should not break anything for people using the thether-tooltip-and-popover by itself.

This should fix the glimmer 2 exceptions people are having when using this addon (https://github.com/sir-dunxalot/ember-tooltips/issues/122).