### PR TITLE
Avoid creating additional runloops while destroying tooltips

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -201,12 +201,10 @@ export default Component.extend({
         eventName,
       } = tooltipEvent;
 
-      run(() => {
-        target.removeEventListener(eventName, callback);
-      });
+      target.removeEventListener(eventName, callback);
     });
 
-    run(this.get('_tooltip').dispose);
+    this.get('_tooltip').dispose();
 
     this._dispatchAction('onDestroy', this);
   },

--- a/tests/acceptance/many-tooltips-test.js
+++ b/tests/acceptance/many-tooltips-test.js
@@ -1,0 +1,46 @@
+import { currentURL, settled, triggerEvent, visit } from '@ember/test-helpers';
+import $ from 'jquery';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import {
+  assertTooltipNotRendered,
+  assertTooltipRendered,
+  assertTooltipVisible,
+} from 'ember-tooltips/test-support';
+
+module('Acceptance | many-tooltips', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('does not raise infinite render invalidation errors when destroying many tooltips', async function(assert) {
+    assert.expect(63);
+
+    await visit('/many-tooltips');
+    assert.equal(currentURL(), '/many-tooltips');
+
+    assertTooltipNotRendered(assert);
+
+    const tooltips = new Uint8Array(15).reduce((acc, _, i) => {
+      acc.push(`.tooltip-${i + 1}`);
+      return acc;
+    }, []);
+
+    for (const tooltip of tooltips) {
+      const $tooltipTarget = $(`${tooltip}-target`);
+      const [ tooltipTarget ] = $tooltipTarget;
+      const tooltipOptions = {
+        selector: tooltip,
+      };
+
+      assert.equal($tooltipTarget.length, 1, 'there should be one $tooltipTarget');
+      assertTooltipNotRendered(assert, tooltipOptions);
+      await triggerEvent(tooltipTarget, 'mouseenter')
+      assertTooltipRendered(assert, tooltipOptions);
+      assertTooltipVisible(assert, tooltipOptions);
+    }
+
+    await settled();
+    await visit('/');
+
+    assert.equal(currentURL(), '/');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('acceptance');
+  this.route('many-tooltips');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/many-tooltips.js
+++ b/tests/dummy/app/routes/many-tooltips.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/templates/many-tooltips.hbs
+++ b/tests/dummy/app/templates/many-tooltips.hbs
@@ -1,0 +1,80 @@
+<div class="tooltip-1-target">
+  tooltip 1
+
+  {{#ember-tooltip tooltipClassName='ember-tooltip tooltip-1'}}
+    tooltip-1!
+  {{/ember-tooltip}}
+</div>
+
+<div class="tooltip-2-target">
+  tooltip 2
+
+  {{#ember-tooltip tooltipClassName='ember-tooltip tooltip-2'}}
+    Here is the info!
+  {{/ember-tooltip}}
+</div>
+
+<div class="tooltip-3-target">
+  tooltip 3
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-3' text='tooltip-3'}}
+</div>
+
+<div class="tooltip-4-target">
+  tooltip 4
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-4' text='tooltip-4'}}
+</div>
+
+<div class="tooltip-5-target">
+  tooltip 5
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-5' text='tooltip-5'}}
+</div>
+
+<div class="tooltip-6-target">
+  tooltip 6
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-6' text='tooltip-6'}}
+</div>
+
+<div class="tooltip-7-target">
+  tooltip 7
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-7' text='tooltip-7'}}
+</div>
+
+<div class="tooltip-8-target">
+  tooltip 8
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-8' text='tooltip-8'}}
+</div>
+
+<div class="tooltip-9-target">
+  tooltip 9
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-9' text='tooltip-9'}}
+</div>
+
+<div class="tooltip-10-target">
+  tooltip 10
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-10' text='tooltip-10'}}
+</div>
+
+<div class="tooltip-11-target">
+  tooltip 11
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-11' text='tooltip-11'}}
+</div>
+
+<div class="tooltip-12-target">
+  tooltip 12
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-12' text='tooltip-12'}}
+</div>
+
+<div class="tooltip-13-target">
+  tooltip 13
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-13' text='tooltip-13'}}
+</div>
+
+<div class="tooltip-14-target">
+  tooltip 14
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-14' text='tooltip-14'}}
+</div>
+
+<div class="tooltip-15-target">
+  tooltip 15
+  {{ember-tooltip tooltipClassName='ember-tooltip tooltip-15' text='tooltip-15'}}
+</div>


### PR DESCRIPTION
Because both popper.js/tooltip.js's `dispose` and `Element.removeEventListener` are synchronous, and `willDestroyElement` runs inside of a runloop, the wrapping is unnecessary.

Fixes #273