### PR TITLE
Fix compatibility breaks in 3.x tooltip test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ test('Example test', async function(assert) {
   await triggerEvent(this, this.element);
 
   assertTooltipVisible(assert, {
-    selector: '.target-b', // Or whatever class you added to the target element
+    targetSelector: '.target-b', // Or whatever class you added to the target element
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -389,9 +389,6 @@ Four actions are available for you to hook onto through the tooltip/popover life
 }}
 ```
 
-As of 2.11.0, specifying just the name of an action (e.g. `'onDestroy'`) is
-deprecated, and will be removed in 3.0.0. Please use closure actions instead.
-
 ## Testing
 
 ### Test helpers
@@ -456,6 +453,11 @@ test('Example test', async function(assert) {
   });
 });
 ```
+
+The [options hash](#test-helper-options) accepts:
+
+- [`contentString`](#test-helper-option-contentstring)
+- [`selector`](#test-helper-option-selector)
 
 #### assertTooltipRendered()
 
@@ -616,7 +618,9 @@ test('Example test', async function(assert) {
 
 The [options hash](#test-helper-options) accepts:
 
+- [`selector`](#test-helper-option-selector)
 - [`side`](#test-helper-option-side)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipSpacing()
 
@@ -627,7 +631,7 @@ This helper tests [the spacing option](#spacing) that can be passed to tooltips 
 An options hash is required and it must contain `spacing` and `side` properties. For example:
 
 ```js
-import { assertTooltipSide } from 'ember-tooltips/test-support';
+import { assertTooltipSpacing } from 'ember-tooltips/test-support';
 
 test('Example test', async function(assert) {
 
@@ -635,7 +639,7 @@ test('Example test', async function(assert) {
 
   /* Asserts that the tooltip is rendered but not shown when the user hovers over the target, which is this test's element */
 
-  assertTooltipSide(assert, {
+  assertTooltipSpacing(assert, {
     side: 'right', // Side is required
     spacing: 35,
   });
@@ -644,8 +648,10 @@ test('Example test', async function(assert) {
 
 The [options hash](#test-helper-options) accepts:
 
+- [`selector`](#test-helper-option-selector)
 - [`side`](#test-helper-option-side)
 - [`spacing`](#test-helper-option-spacing)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 ### Test helper options
 
@@ -655,6 +661,7 @@ Most test helpers accept a second, optional param called `options`. This is an o
 - [Selector](#test-helper-option-selector)
 - [Side](#test-helper-option-side)
 - [Spacing](#test-helper-option-spacing)
+- [Target selector](#test-helper-option-targetselector)
 
 #### Test helper option: `contentString`
 
@@ -757,6 +764,42 @@ test('Example test', async function(assert) {
   assertTooltipSide(assert, {
     side: 'right', // Side is required
     spacing: 35,
+  });
+});
+```
+
+#### Test helper option: `targetSelector`
+
+The selector of the target element of the tooltip or popover you are testing.
+
+If more than one tooltip or popover is found in the DOM with a particular selector
+when you run an assertion, you will be asked to specify this.
+
+| Type    | String |
+|---------|---------|
+| Default | `'.ember-tooltip-target, .ember-popover-target'` |
+
+Usage example:
+
+```js
+import { render, triggerEvent } from '@ember/test-helpers';
+import { assertTooltipVisible } from 'ember-tooltips/test-support';
+
+test('Example test', async function(assert) {
+
+  await render(hbs`
+    <div class="target-a">
+      {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
+    </div>
+    <div class="target-b">
+      {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+    </div>
+  `);
+
+  await triggerEvent(this, this.element);
+
+  assertTooltipVisible(assert, {
+    selector: '.target-b', // Or whatever class you added to the target element
   });
 });
 ```

--- a/addon-test-support/assertions/assert-tooltip-content.js
+++ b/addon-test-support/assertions/assert-tooltip-content.js
@@ -3,13 +3,13 @@ import { isNone } from '@ember/utils';
 import { findTooltip } from 'ember-tooltips/test-support';
 
 export default function assertTooltipContent(assert, options = {}) {
-  const { contentString } = options;
+  const { contentString, selector } = options;
 
   if (isNone(contentString)) {
     emberAssert('You must specify a contentString property in the options parameter');
   }
 
-  const $tooltip = findTooltip();
+  const $tooltip = findTooltip(selector);
   const tooltipContent = $tooltip.text().trim();
 
   assert.equal(tooltipContent, contentString,

--- a/addon-test-support/assertions/assert-tooltip-visible.js
+++ b/addon-test-support/assertions/assert-tooltip-visible.js
@@ -1,6 +1,6 @@
 import { findTooltip } from 'ember-tooltips/test-support';
 
-export default function assertTooltipNotVisible(assert, options = {}) {
+export default function assertTooltipVisible(assert, options = {}) {
   const { selector } = options;
   const $tooltip = findTooltip(selector);
   const ariaHidden = $tooltip.attr('aria-hidden');

--- a/addon-test-support/utils/find-tooltip.js
+++ b/addon-test-support/utils/find-tooltip.js
@@ -11,7 +11,12 @@ export default function findTooltip(selector) {
   children of <body> instead of children of the $targetElement */
 
   const $body = $(document.body);
-  const $tooltip = $body.find(selector);
+  let $tooltip = $body.find(selector);
+
+  if ($tooltip.length && $tooltip.hasClass('ember-tooltip-base')) {
+    const $target = $tooltip.parents('.ember-tooltip-target, .ember-popover-target');
+    $tooltip = $body.find(`#${$target.attr('aria-describedby')}`);
+  }
 
   if ($tooltip.length && !$tooltip.hasClass('ember-tooltip') && !$tooltip.hasClass('ember-popover')) {
     throw Error(`getTooltipFromBody(): returned an element that is not a tooltip`);

--- a/addon-test-support/utils/find-tooltip.js
+++ b/addon-test-support/utils/find-tooltip.js
@@ -14,6 +14,10 @@ export default function findTooltip(selector) {
   let $tooltip = $body.find(selector);
 
   if ($tooltip.length && $tooltip.hasClass('ember-tooltip-base')) {
+    /* If what we find is the actually the tooltip component's element, we can
+     * look up the intended tooltip by the element referenced by its target
+     * element's aria-describedby attribute.
+     */
     const $target = $tooltip.parents('.ember-tooltip-target, .ember-popover-target');
     $tooltip = $body.find(`#${$target.attr('aria-describedby')}`);
   }

--- a/addon-test-support/utils/get-position-differences.js
+++ b/addon-test-support/utils/get-position-differences.js
@@ -46,9 +46,10 @@ export default function getPositionDifferences(options = {}) {
   return { expectedGreaterDistance, expectedLesserDistance };
 }
 
-export function getTooltipAndTargetPosition() {
-  const [ target ] = findTooltipTarget();
-  const [ tooltip ] = findTooltip();
+export function getTooltipAndTargetPosition(options = {}) {
+  const { selector, targetSelector } = options;
+  const [ target ] = findTooltipTarget(targetSelector);
+  const [ tooltip ] = findTooltip(selector);
 
   const targetPosition = target.getBoundingClientRect();
   const tooltipPosition = tooltip.getBoundingClientRect();

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -61,4 +61,19 @@ module('Integration | Option | content', function(hooks) {
       contentString: 'foo',
     });
   });
+
+  test('assertTooltipContent supports passing a selector to target a specific tooltip', async function(assert) {
+
+    assert.expect(1);
+
+    await render(hbs`
+      {{ember-tooltip class='some-garbage-tooltip' text='foo' isShown=true}}
+      {{ember-tooltip class='the-best-tooltip' text='bar' isShown=true}}
+    `);
+
+    assertTooltipContent(assert, {
+      contentString: 'bar',
+      selector: '.the-best-tooltip'
+    });
+  });
 });

--- a/tests/integration/components/helpers/find-tooltip-test.js
+++ b/tests/integration/components/helpers/find-tooltip-test.js
@@ -30,6 +30,22 @@ module('Integration | Helpers | findTooltip', function(hooks) {
     });
   });
 
+  test('findTooltip() can find a tooltip based on the class passed to the component', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{ember-tooltip text='hello' class='js-tooltip-component-element' isShown=true}}`);
+
+    assertTooltipRendered(assert, { selector: '.js-tooltip-component-element' });
+  });
+
+  test('findTooltip() can find a tooltip based on tooltipClassName passed to the component', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{ember-tooltip text='hello' tooltipClassName='ember-tooltip js-class-on-the-popper-element' isShown=true}}`);
+
+    assertTooltipRendered(assert, { selector: '.js-class-on-the-popper-element' });
+  });
+
   test('findTooltip() will not throw en error with assertTooltipNotRendered', async function(assert) {
     assert.expect(1);
 

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -61,4 +61,24 @@ module('Integration | Option | side', function(hooks) {
 
     assertTooltipSide(assert, { side: 'left' });
   });
+
+
+  test('assertTooltipSide supports a targetSelector option', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <div class="target-a">
+        {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
+      </div>
+      <div class="target-b">
+        {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+      </div>
+    `);
+
+    assertTooltipSide(assert, {
+      side: 'left',
+      selector: '.common-tooltip',
+      targetSelector: '.target-b'
+    });
+  });
 });


### PR DESCRIPTION
Restores `targetSelector` option, which is useful for targeting based
a specific tooltip out of many when tooltips share a common class, but
have differentiatable target elements.

Also, restores the ability to target based on the `class` passed to
`{{ember-tooltip}}`.

With these changes in place, host app test suites should be able to migrate over from 2.x fairly cleanly.