### PR TITLE
Prevent tooltip from adding target element's title attribute to tooltip - fixes #224

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -317,6 +317,11 @@ export default Component.extend({
           const rootElement = document.querySelector(config.APP.rootElement);
           const target = this.get('target');
           const tooltipClassName = this.get('tooltipClassName');
+
+          const targetTitle = target.title;
+
+          target.removeAttribute('title');
+
           const tooltip = new Tooltip(target, {
             container: rootElement || false,
             html: true,
@@ -352,6 +357,8 @@ export default Component.extend({
 
                     popperInstance.update();
                   });
+
+                  target.setAttribute('title', targetTitle);
 
                   resolve(tooltipData);
                 });

--- a/tests/integration/components/title-test.js
+++ b/tests/integration/components/title-test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
-  assertTooltipRendered,
   assertTooltipContent,
+  assertTooltipNotVisible,
+  assertTooltipVisible,
   findTooltipTarget,
 } from 'ember-tooltips/test-support';
 
@@ -12,21 +13,37 @@ module('Integration | Component | title', function(hooks) {
   setupRenderingTest(hooks);
 
   test(`ember-tooltip uses text instead of parent's title attribute`, async function(assert) {
-    assert.expect(3);
+    assert.expect(5);
 
     await render(hbs`
       <div title="Hover for more info">
-        {{ember-tooltip text='Here is more info' isShown=true}}
+        {{ember-tooltip text='Here is more info'}}
       </div>
     `);
 
-    assertTooltipRendered(assert);
+    const [ target ] = findTooltipTarget();
+
+    await triggerEvent(target, 'mouseenter');
+
+    assertTooltipVisible(assert);
 
     assertTooltipContent(assert, {
       contentString: 'Here is more info',
     });
 
-    assert.equal(findTooltipTarget().attr('title'), 'Hover for more info',
+    /* Reshow the tooltip and check it's content is still correct */
+
+    await triggerEvent(target, 'mouseleave');
+
+    assertTooltipNotVisible(assert);
+
+    await triggerEvent(target, 'mouseenter');
+
+    assertTooltipContent(assert, {
+      contentString: 'Here is more info',
+    });
+
+    assert.equal(target.title, 'Hover for more info',
       'The target should have the original title');
   });
 });

--- a/tests/integration/components/title-test.js
+++ b/tests/integration/components/title-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  assertTooltipRendered,
+  assertTooltipContent,
+  findTooltipTarget,
+} from 'ember-tooltips/test-support';
+
+module('Integration | Component | title', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test(`ember-tooltip uses text instead of parent's title attribute`, async function(assert) {
+    assert.expect(3);
+
+    await render(hbs`
+      <div title="Hover for more info">
+        {{ember-tooltip text='Here is more info' isShown=true}}
+      </div>
+    `);
+
+    assertTooltipRendered(assert);
+
+    assertTooltipContent(assert, {
+      contentString: 'Here is more info',
+    });
+
+    assert.equal(findTooltipTarget().attr('title'), 'Hover for more info',
+      'The target should have the original title');
+  });
+});


### PR DESCRIPTION
Fixes #224 by temporarily removing a tooltip's target's `title` attribute whilst the tooltip renders.

The reason I am taking an unusual, DOM-hacky approach to this bug is because the functionality causing this issue is deep within `popper.js` source code ([reference here](https://github.com/FezVrasta/popper.js/blob/master/packages/tooltip/src/index.js#L200)).