### PR TITLE
Avoid scheduling additional runloop timers in willDestroyElement

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -208,8 +208,6 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
 
-    this.hide();
-
     const _tooltipEvents = this.get('_tooltipEvents');
 
     /* Remove event listeners used to show and hide the tooltip */
@@ -223,6 +221,8 @@ export default Component.extend({
 
       target.removeEventListener(eventName, callback);
     });
+
+    this._cleanupTimers();
 
     this.get('_tooltip').dispose();
 
@@ -580,6 +580,11 @@ export default Component.extend({
     if (!this.isDestroying && !this.isDestroyed && action) {
       action(...args);
     }
+  },
+
+  _cleanupTimers() {
+    run.cancel(this.get('_showTimer'));
+    cancelAnimationFrame(this._spacingRequestId);
   }
 });
 


### PR DESCRIPTION
Ember does not set the isDestroying flag when willDestroyElement is called,
meaning the guards on `hide()` are not triggered, resulting in timers being
scheduled. Luckily, we don't need to call the full `hide()`, we just need to
cancel some timers. We call `dispose()` on the tooltip.js instance, which
already handles [hiding the tooltip](https://github.com/FezVrasta/popper.js/blob/b98d9134eb78b97e8bc1b736401a960e9e3cb9f6/packages/tooltip/src/index.js\#L278).

This fixes an issue where the timers set during tooltip teardown could
bleed into other acceptance tests and wreck havoc with runloop waiting
behavior.