### PR TITLE
promote ember-get-config to a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-node-assets": "^0.2.2",
+    "ember-get-config": "^0.2.4",
     "ember-wormhole": "^0.5.5",
     "popper.js": "^1.12.5",
     "tooltip.js": "^1.1.5"
@@ -56,7 +57,6 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^5.1.3",
-    "ember-get-config": "^0.2.4",
     "ember-line-clamp": "^0.2.16",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
I was getting the error `Could not find module 'ember-get-config' imported from 'ember-tooltips/components/ember-tooltip-base'` at runtime.