### PR TITLE
Add container option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ For example, if you want to show a tooltip over a button when the user hovers ov
 Options are set as attributes on the tooltip/popover components. Current tooltip/popover properties this addon supports are:
 
 - [class](#class)
+- [container](#container)
 - [delay](#delay)
 - [delayOnChange](#delay-on-change)
 - [duration](#duration)
@@ -147,6 +148,20 @@ Adds a class to any tooltip:
 
 ```hbs
 {{ember-tooltip class='tooltip-warning'}}
+```
+
+#### Container
+
+| Type | HTMLElement \| String \| false |
+|---|---|
+| Default | false |
+
+Appends the tooltip to a specific element.  By default, the tooltip will be rendered as a sibling of its target. This attribute can be set to render the tooltip elsewhere in the DOM.  See the [tooltip.js container option](https://popper.js.org/tooltip-documentation.html#new_Tooltip_new).
+
+```hbs
+{{!--Renders the tooltip as a child of the body element--}}
+
+{{ember-tooltip container='body'}}
 ```
 
 #### Delay

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ This option does not affect the event the tooltip shows on. That is set by the [
 
 #### Popper container
 
-| Type | HTMLElement, String, or false |
+| Type | `HTMLElement` \| `String` \| `false` |
 |---|---|
 | Default | false |
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ For example, if you want to show a tooltip over a button when the user hovers ov
 Options are set as attributes on the tooltip/popover components. Current tooltip/popover properties this addon supports are:
 
 - [class](#class)
-- [container](#container)
 - [delay](#delay)
 - [delayOnChange](#delay-on-change)
 - [duration](#duration)
@@ -132,6 +131,7 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 - [hideDelay (popover only)](#hide-delay)
 - [hideOn](#hide-on)
 - [isShown](#is-shown)
+- [popperContainer](#popper-container)
 - [popperOptions](#popper-options)
 - [side](#side)
 - [showOn](#show-on)
@@ -148,20 +148,6 @@ Adds a class to any tooltip:
 
 ```hbs
 {{ember-tooltip class='tooltip-warning'}}
-```
-
-#### Container
-
-| Type | HTMLElement \| String \| false |
-|---|---|
-| Default | false |
-
-Appends the tooltip to a specific element.  By default, the tooltip will be rendered as a sibling of its target. This attribute can be set to render the tooltip elsewhere in the DOM.  See the [tooltip.js container option](https://popper.js.org/tooltip-documentation.html#new_Tooltip_new).
-
-```hbs
-{{!--Renders the tooltip as a child of the body element--}}
-
-{{ember-tooltip container='body'}}
 ```
 
 #### Delay
@@ -276,6 +262,20 @@ This can be any javascript-emitted event.
 Usually, you'll use the `event` option, which sets `showOn` and `hideOn` automatically, instead of this option.
 
 This option does not affect the event the tooltip shows on. That is set by the [showOn](#show-on) option. This will override [the event property](#event) in deciding when the tooltip is hidden.
+
+#### Popper container
+
+| Type | HTMLElement, String, or false |
+|---|---|
+| Default | false |
+
+Appends the tooltip to a specific element.  By default, the tooltip will be rendered as a sibling of its target. This attribute can be set to render the tooltip elsewhere in the DOM.  See the [tooltip.js container option](https://popper.js.org/tooltip-documentation.html#new_Tooltip_new).
+
+```hbs
+{{!--Renders the tooltip as a child of the body element--}}
+
+{{ember-tooltip popperContainer='body'}}
+```
 
 #### Popper options
 

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -87,6 +87,7 @@ export default Component.extend({
   layout,
   updateFor: null,
   popperOptions: null,
+  container: false,
 
   /* Actions */
 
@@ -314,7 +315,6 @@ export default Component.extend({
 
       try {
         run(() => {
-          const rootElement = document.querySelector(config.APP.rootElement);
           const target = this.get('target');
           const tooltipClassName = this.get('tooltipClassName');
 
@@ -323,7 +323,7 @@ export default Component.extend({
           target.removeAttribute('title');
 
           const tooltip = new Tooltip(target, {
-            container: rootElement || false,
+            container: this.get('container'),
             html: true,
             placement: this.get('side'),
             title: '<span></span>',

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -87,7 +87,7 @@ export default Component.extend({
   layout,
   updateFor: null,
   popperOptions: null,
-  container: false,
+  popperContainer: false,
 
   /* Actions */
 
@@ -323,7 +323,7 @@ export default Component.extend({
           target.removeAttribute('title');
 
           const tooltip = new Tooltip(target, {
-            container: this.get('container'),
+            container: this.get('popperContainer'),
             html: true,
             placement: this.get('side'),
             title: '<span></span>',

--- a/tests/integration/components/container-test.js
+++ b/tests/integration/components/container-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  findTooltip,
+  findTooltipTarget,
+} from 'ember-tooltips/test-support';
+
+module('Integration | Option | container', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('by default, the tooltip is rendered adjacent to its target', async function(assert) {
+    await render(hbs`
+      <div id='tooltip-target'>
+        {{ember-tooltip text='tooltip-text'}}
+      </div>
+    `);
+    const expectedContainer = this.element;
+    const [ target ] = findTooltipTarget();
+    await triggerEvent(target, 'mouseenter');
+    const tooltip = findTooltip();
+    assert.equal(tooltip.parent()[0], expectedContainer,
+      'The tooltip should be a sibling of its target');
+  });
+
+  test('the container attribute allows the tooltip parent to be set', async function(assert) {
+    await render(hbs`
+      <div id='tooltip-container'></div>
+      <div id='tooltip-target'>
+        {{ember-tooltip text='tooltip-text' container='#tooltip-container'}}
+      </div>
+    `);
+    const expectedContainer = find('#tooltip-container');
+    const [ target ] = findTooltipTarget();
+    await triggerEvent(target, 'mouseenter');
+    const tooltip = findTooltip();
+    assert.equal(tooltip.parent()[0], expectedContainer,
+      'The element identified by the container attribute should be the tooltip parent');
+  });
+});

--- a/tests/integration/components/container-test.js
+++ b/tests/integration/components/container-test.js
@@ -7,7 +7,7 @@ import {
   findTooltipTarget,
 } from 'ember-tooltips/test-support';
 
-module('Integration | Option | container', function(hooks) {
+module('Integration | Option | popperContainer', function(hooks) {
   setupRenderingTest(hooks);
 
   test('by default, the tooltip is rendered adjacent to its target', async function(assert) {
@@ -24,11 +24,11 @@ module('Integration | Option | container', function(hooks) {
       'The tooltip should be a sibling of its target');
   });
 
-  test('the container attribute allows the tooltip parent to be set', async function(assert) {
+  test('the popperContainer attribute allows the tooltip parent to be set', async function(assert) {
     await render(hbs`
       <div id='tooltip-container'></div>
       <div id='tooltip-target'>
-        {{ember-tooltip text='tooltip-text' container='#tooltip-container'}}
+        {{ember-tooltip text='tooltip-text' popperContainer='#tooltip-container'}}
       </div>
     `);
     const expectedContainer = find('#tooltip-container');
@@ -36,6 +36,6 @@ module('Integration | Option | container', function(hooks) {
     await triggerEvent(target, 'mouseenter');
     const tooltip = findTooltip();
     assert.equal(tooltip.parent()[0], expectedContainer,
-      'The element identified by the container attribute should be the tooltip parent');
+      'The element identified by the popperContainer attribute should be the tooltip parent');
   });
 });


### PR DESCRIPTION
Proposed solution for https://github.com/sir-dunxalot/ember-tooltips/issues/304

Adds a `container` attribute to the `ember-tooltip` component, which is passed down as [tooltip.js' container option](https://popper.js.org/tooltip-documentation.html#new_Tooltip_new).  It defaults to `false`, which will render the tooltip as a sibling of its target.  Optionally, it can be set to an element or selector that identifies an alternate container for the tooltip.

In this changeset, the `APP.rootElement` config property is ignored - it used to be used to populate the container.  The previous behavior prevented apps that have this config property set from being able to render tooltips in-place.