### PR TITLE
Remove ember-cli-node-assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,32 +3,10 @@
 module.exports = {
   name: require('./package').name,
 
-  options: {
-    nodeAssets: {
-
-      'popper.js': {
-        vendor: {
-          srcDir: 'dist/umd',
-          destDir: 'popper',
-          include: ['popper.js', 'popper.js.map'],
-        },
-      },
-
-      'tooltip.js': {
-        vendor: {
-          srcDir: 'dist/umd',
-          destDir: 'popper',
-          include: ['tooltip.js', 'tooltip.js.map'],
-        },
-      },
-    },
-  },
-
   included: function(app) {
     this._super.included(app);
 
-    app.import('vendor/popper/popper.js');
-    app.import('vendor/popper/tooltip.js');
-  },
-
+    app.import(`${this.project.root}/node_modules/popper.js/dist/umd/popper.js`);
+    app.import(`${this.project.root}/node_modules/tooltip.js/dist/umd/tooltip.js`);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.16.0",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-cli-node-assets": "^0.2.2",
     "ember-get-config": "^0.2.4",
     "ember-wormhole": "^0.5.5",
     "popper.js": "^1.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,7 +1767,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
+broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -2860,17 +2860,6 @@ ember-cli-lodash-subset@2.0.1, ember-cli-lodash-subset@^2.0.1:
 ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
-
-ember-cli-node-assets@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-source "^1.1.0"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -5357,7 +5346,7 @@ lodash.values@~2.3.0:
   dependencies:
     lodash.keys "~2.3.0"
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -6605,7 +6594,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.3, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.1.3, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
Hey there 👋

This removes the use of `ember-cli-node-assets` which is, in the words of maintainer, "[mostly obsolete](https://github.com/dfreeman/ember-cli-node-assets#ember-cli-node-assets--)" in favour of importing from `node_modules` directly. 

I'm not sure which versions of Ember this addon wishes to support, but directly importing node_modules was added in 2.15, so this will break in versions earlier than that.

This fixes https://github.com/sir-dunxalot/ember-tooltips/issues/277 at least in that specific case (I work with @shanicem, who opened that issue)