### PR TITLE
Remove small use of jQuery in ember-tooltip-base

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -1,6 +1,4 @@
 /* global Tooltip */
-
-import $ from 'jquery';
 import Ember from 'ember';
 import { computed } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -480,7 +478,7 @@ export default Component.extend({
       already a tooltip/popover shown in the DOM. Check that here
       and adjust the delay as needed. */
 
-      let shownTooltipsOrPopovers = $(`.${ANIMATION_CLASS}`);
+      let shownTooltipsOrPopovers = document.querySelectorAll(`.${ANIMATION_CLASS}`);
 
       if (shownTooltipsOrPopovers.length) {
         delay = 0;


### PR DESCRIPTION
First PR to help address #307. This will remove the only run-time dependency on jQuery that we have.