### PR TITLE
Fix flaky test by mimicking mouse events

### DIFF
--- a/tests/integration/components/popover/api-test.js
+++ b/tests/integration/components/popover/api-test.js
@@ -51,11 +51,12 @@ module('Integration | Option | API', function(hooks) {
 
     assertTooltipNotRendered(assert);
 
-    await triggerEvent(element, 'click');
+    await click(element);
 
     assertTooltipVisible(assert);
 
     await click('.hide-action');
+    await triggerEvent(element, "mouseleave");
 
     assertTooltipNotVisible(assert);
 


### PR DESCRIPTION
The click on element and click on hide-action both simulate the related mouse events, which have an impact on how the popover is shown and hidden (popover will avoid hiding if mouse is present.) Therefore, we simulate leaving the element so that it hides every time!

(* I'm 96% sure that's what was happening here.)

Fixes #305 