### PR TITLE
Replace ember-wormhole with ember-maybe-in-element

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -160,6 +160,14 @@ export default Component.extend({
     return `${this.get('elementId')}-wormhole`;
   }),
 
+  wormholeEl: computed('wormholeId', '_awaitingTooltipElementRendered', function() {
+    if (this.get('_awaitingTooltipElementRendered')) {
+      return null;
+    } else {
+      return document.getElementById(this.get('wormholeId'));
+    }
+  }),
+
   _awaitingTooltipElementRendered: true,
   _tooltipEvents: null,
   _tooltip: null,

--- a/addon/templates/components/ember-tooltip-base.hbs
+++ b/addon/templates/components/ember-tooltip-base.hbs
@@ -1,4 +1,4 @@
-{{#ember-wormhole to=wormholeId renderInPlace=_awaitingTooltipElementRendered}}
+{{#maybe-in-element wormholeEl _awaitingTooltipElementRendered}}
   <div>
     {{#if (hasBlock)}}
       {{yield this}}
@@ -6,4 +6,4 @@
       {{text}}
     {{/if}}
   </div>
-{{/ember-wormhole}}
+{{/maybe-in-element}}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-babel": "^6.16.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-get-config": "^0.2.4",
-    "ember-wormhole": "^0.5.5",
+    "ember-maybe-in-element": "^0.2.0",
     "popper.js": "^1.12.5",
     "tooltip.js": "^1.1.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,7 +2707,7 @@ ember-assign-polyfill@~2.4.0:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.17.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
   dependencies:
@@ -3097,6 +3097,13 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-maybe-in-element@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.2.0.tgz#9ac51cbbd9d83d6230ad996c11e33f0eca3032e0"
+  integrity sha512-R5e6N8yDbfNbA/3lMZsFs2KEzv/jt80TsATiKMCqdqKuSG82KrD25cRdU5VkaE8dTQbziyBeuJs90bBiqOnakQ==
+  dependencies:
+    ember-cli-babel "^7.1.0"
+
 ember-qunit@^3.4.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.5.3.tgz#bfd0bff8298c78c77e870cca43fe0826e78a0d09"
@@ -3201,13 +3208,6 @@ ember-try@^1.0.0:
     rimraf "^2.3.2"
     rsvp "^4.7.0"
     walk-sync "^0.3.3"
-
-ember-wormhole@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.5.tgz#db417ff748cb21e574cd5f233889897bc27096cb"
-  dependencies:
-    ember-cli-babel "^6.10.0"
-    ember-cli-htmlbars "^2.0.1"
 
 emit-function@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
ember-maybe-in-element leverages the Glimmer native `-in-element`
helper to render content into another DOM node. This allows us to
drop ember-wormhole and may address the issues raised in #309.