### PR TITLE
Fix issue hide/show race by cancelling the final hide callback on show

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -423,6 +423,7 @@ export default Component.extend({
     const duration = this.get('duration');
 
     run.cancel(this.get('_showTimer'));
+    run.cancel(this.get('_completeHideTimer'));
 
     if (duration) {
       this.setHideTimer(duration);
@@ -488,7 +489,7 @@ export default Component.extend({
       _tooltip.popperInstance.popper.classList.remove(ANIMATION_CLASS);
     }
 
-    run.later(() => {
+    const _completeHideTimer = run.later(() => {
 
       if (this.get('isDestroying')) {
         return;
@@ -501,6 +502,8 @@ export default Component.extend({
       this.set('isShown', false);
       this._dispatchAction('onHide', this);
     }, this.get('_animationDuration'));
+    
+    this.set('_completeHideTimer', _completeHideTimer);
   },
 
   _showTooltip() {

--- a/tests/integration/components/show-hide-show-test.js
+++ b/tests/integration/components/show-hide-show-test.js
@@ -1,0 +1,28 @@
+import { later } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  assertTooltipNotRendered,
+  assertTooltipVisible,
+} from 'ember-tooltips/test-support';
+
+module('Integration | Component | show-hide-show', function(hooks) {
+  setupRenderingTest(hooks);
+
+  //Prevents a race condition regression between hiding and showing the tooltip when the user moves their mouse over quickly.
+  test('ember-tooltip shows after quickly showing then hiding then showing again.', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`{{ember-tooltip}}`);
+
+    assertTooltipNotRendered(assert);
+    triggerEvent(this.element, 'mouseenter');
+    triggerEvent(this.element, 'mouseleave');
+    triggerEvent(this.element, 'mouseenter');
+
+    //Wait at least 200 ms (animation time) for a hide to potentially fire then check for visibility. Should still be visible.
+    later(() => assertTooltipVisible(assert), 250);
+  });
+});


### PR DESCRIPTION
Suggested fix for issue #321

Added a `_completeHideTimer` to track the final `run.later` which actually completes the hiding of the tooltip. This is different than the `_hideTimer` which tracks a desired hide of the tooltip based on a duration supplied by the user.

This timer gets cancelled on every show to prevent a race condition between showing and hiding the tooltip.

