### PR TITLE
Fix keydown bubbling

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -293,7 +293,8 @@ export default Component.extend({
     this._addEventListener('keydown', (keyEvent) => {
 
       if (keyEvent.which === 27) {
-        if (this.hide()) {
+        if (this.get('isShown')) {
+          this.hide();
           keyEvent.stopImmediatePropagation(); /* So this callback only fires once per keydown */
           keyEvent.preventDefault();
           return false;
@@ -408,7 +409,7 @@ export default Component.extend({
 
     run.cancel(this.get('_showTimer'));
 
-    return this._hideTooltip();
+    this._hideTooltip();
   },
 
   show() {
@@ -480,7 +481,7 @@ export default Component.extend({
     const _tooltip = this.get('_tooltip');
 
     if (!_tooltip || this.get('isDestroying')) {
-      return false;
+      return;
     }
 
     if (_tooltip.popperInstance) {
@@ -490,7 +491,7 @@ export default Component.extend({
     const _completeHideTimer = run.later(() => {
 
       if (this.get('isDestroying')) {
-        return false;
+        return;
       }
 
       cancelAnimationFrame(this._spacingRequestId);
@@ -499,7 +500,6 @@ export default Component.extend({
       this.set('_isHiding', false);
       this.set('isShown', false);
       this._dispatchAction('onHide', this);
-      return true;
     }, this.get('_animationDuration'));
     
     this.set('_completeHideTimer', _completeHideTimer);

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -292,13 +292,11 @@ export default Component.extend({
 
     this._addEventListener('keydown', (keyEvent) => {
 
-      if (keyEvent.which === 27) {
-        if (this.get('isShown')) {
-          this.hide();
-          keyEvent.stopImmediatePropagation(); /* So this callback only fires once per keydown */
-          keyEvent.preventDefault();
-          return false;
-        }
+      if (keyEvent.which === 27 && this.get('isShown')) {
+        this.hide();
+        keyEvent.stopImmediatePropagation(); /* So this callback only fires once per keydown */
+        keyEvent.preventDefault();
+        return false;
       }
     }, document);
   },

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -292,14 +292,12 @@ export default Component.extend({
 
     this._addEventListener('keydown', (keyEvent) => {
 
-      keyEvent.stopImmediatePropagation(); /* So this callback only fires once per keydown */
-
       if (keyEvent.which === 27) {
-        this.hide();
-
-        keyEvent.preventDefault();
-
-        return false;
+        if (this.hide()) {
+          keyEvent.stopImmediatePropagation(); /* So this callback only fires once per keydown */
+          keyEvent.preventDefault();
+          return false;
+        }
       }
     }, document);
   },
@@ -410,7 +408,7 @@ export default Component.extend({
 
     run.cancel(this.get('_showTimer'));
 
-    this._hideTooltip();
+    return this._hideTooltip();
   },
 
   show() {
@@ -482,7 +480,7 @@ export default Component.extend({
     const _tooltip = this.get('_tooltip');
 
     if (!_tooltip || this.get('isDestroying')) {
-      return;
+      return false;
     }
 
     if (_tooltip.popperInstance) {
@@ -492,7 +490,7 @@ export default Component.extend({
     const _completeHideTimer = run.later(() => {
 
       if (this.get('isDestroying')) {
-        return;
+        return false;
       }
 
       cancelAnimationFrame(this._spacingRequestId);
@@ -501,6 +499,7 @@ export default Component.extend({
       this.set('_isHiding', false);
       this.set('isShown', false);
       this._dispatchAction('onHide', this);
+      return true;
     }, this.get('_animationDuration'));
     
     this.set('_completeHideTimer', _completeHideTimer);

--- a/tests/integration/components/keydown-test.js
+++ b/tests/integration/components/keydown-test.js
@@ -1,0 +1,45 @@
+//import { later } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, triggerKeyEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  assertTooltipVisible,
+  assertTooltipNotVisible
+} from 'ember-tooltips/test-support';
+
+module('Integration | Component | keydown', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('ember-tooltip esc key triggers single hide', async function(assert) {
+
+    assert.expect(5);
+
+    /* Create two tooltips and hide one after another with two keydown events */
+
+    await render(hbs`
+      {{ember-tooltip isShown=true tooltipClassName='ember-tooltip test-tooltip1' text='I am here'}}
+      {{ember-tooltip isShown=true tooltipClassName='ember-tooltip test-tooltip2' text='I am there'}}
+    `);
+
+    await settled();
+
+    assertTooltipVisible(assert, { selector: '.test-tooltip1' });
+    assertTooltipVisible(assert, { selector: '.test-tooltip2' });
+    
+    const { element } = this;
+    await triggerKeyEvent(element, 'keydown', 27);
+
+    await settled();
+
+    assertTooltipNotVisible(assert, { selector: '.test-tooltip1' });
+    assertTooltipVisible(assert, { selector: '.test-tooltip2' });
+
+    await triggerKeyEvent(element, 'keydown', 27);
+
+    await settled();
+
+    assertTooltipNotVisible(assert, { selector: '.test-tooltip2' });
+
+  });
+});

--- a/tests/integration/components/keydown-test.js
+++ b/tests/integration/components/keydown-test.js
@@ -1,4 +1,3 @@
-//import { later } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, triggerKeyEvent } from '@ember/test-helpers';


### PR DESCRIPTION
The keydown event handler for the escape key stops bubbling/propagation on any esc press.  If there are multiple tooltips loaded then the first tooltip to respond will disable all other tooltips from responding.  

Moreover, ember-tooltips is preventing other listeners from other modules or components from responding as well.

This branch fixes that by only stopping propagation when we know that a tooltip has been hidden.