### PR TITLE
Allow base class to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Adds extra classes to tooltip arrows.
 Usually used along with [`tooltipClass`](#tooltipclass).
 
 ```hbs
-{{ember-tooltip tooltipClass='hoverhelp__arrow'}}
+{{ember-tooltip arrowClass='hoverhelp__arrow'}}
 ```
 
 This will create html similar to:

--- a/README.md
+++ b/README.md
@@ -144,10 +144,47 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 |---------|---------|
 | Default | none    |
 
-Adds a class to any tooltip:
+Adds a class to any tooltip wrapper:
 
 ```hbs
-{{ember-tooltip class='tooltip-warning'}}
+{{ember-tooltip class='tooltip-wrapper'}}
+```
+**Note:** This is usually not what you want, as the wrapper itself is hidden by default. You are probably looking for [`tooltipBaseClass`](#tooltipbaseclass) or [`tooltipClassName`](#tooltipclassname).
+
+#### tooltipBaseClass
+
+| Type    | String          |
+|---------|-----------------|
+| Default | 'tooltip'       |
+
+Modifies the base class used for all tooltip, and extended upon by the tooltip content (`[tooltipBaseClass]-inner`) and the arrow (`[tooltipBaseClass]-arrow`).
+
+Useful to avoid conflicts with other libraries:
+
+```hbs
+{{ember-tooltip tooltipBaseClass='hoverhelp'}}
+```
+
+This will create markup similar to:
+```html
+<div class="hoverhelp">
+  <div class="hoverhelp-arrow"></div>
+  <div class="hoverhelp-inner"><!-- content --></div>
+</div>
+```
+
+#### tooltipClassName
+
+| Type    | String          |
+|---------|-----------------|
+| Default | 'ember-tooltip' |
+
+Adds classes to any tooltip.
+
+Useful for creating variations of tooltip:
+
+```hbs
+{{ember-tooltip tooltipClassName='tooltip-warning'}}
 ```
 
 #### Delay

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 - [spacing](#spacing)
 - [text (tooltip only)](#text)
 
-#### Class
+#### class
 
 | Type    | String  |
 |---------|---------|
@@ -149,42 +149,73 @@ Adds a class to any tooltip wrapper:
 ```hbs
 {{ember-tooltip class='tooltip-wrapper'}}
 ```
-**Note:** This is usually not what you want, as the wrapper itself is hidden by default. You are probably looking for [`tooltipBaseClass`](#tooltipbaseclass) or [`tooltipClassName`](#tooltipclassname).
+**Note:** This is usually not what you want, as the wrapper itself is hidden by default.
+You are probably looking for [`tooltipClass`](#tooltipclass).
 
-#### tooltipBaseClass
+#### tooltipClass
 
 | Type    | String          |
 |---------|-----------------|
 | Default | 'tooltip'       |
 
-Modifies the base class used for all tooltip, and extended upon by the tooltip content (`[tooltipBaseClass]-inner`) and the arrow (`[tooltipBaseClass]-arrow`).
+Adds extra classes to tooltips.
 
-Useful to avoid conflicts with other libraries:
+Useful to avoid conflicts with other libraries.
 
 ```hbs
-{{ember-tooltip tooltipBaseClass='hoverhelp'}}
+{{ember-tooltip tooltipClass='hoverhelp'}}
 ```
 
-This will create markup similar to:
+This will create html similar to:
 ```html
 <div class="hoverhelp">
-  <div class="hoverhelp-arrow"></div>
-  <div class="hoverhelp-inner"><!-- content --></div>
+  <div class="tooltip-arrow"></div>
+  <div class="tooltip-inner"><!-- content --></div>
 </div>
 ```
 
-#### tooltipClassName
+#### arrowClass
 
 | Type    | String          |
 |---------|-----------------|
-| Default | 'ember-tooltip' |
+| Default | 'tooltip-arrow' |
 
-Adds classes to any tooltip.
+Adds extra classes to tooltip arrows.
 
-Useful for creating variations of tooltip:
+Usually used along with [`tooltipClass`](#tooltipclass).
 
 ```hbs
-{{ember-tooltip tooltipClassName='tooltip-warning'}}
+{{ember-tooltip tooltipClass='hoverhelp__arrow'}}
+```
+
+This will create html similar to:
+```html
+<div class="tooltip">
+  <div class="hoverhelp__arrow"></div>
+  <div class="tooltip-inner"><!-- content --></div>
+</div>
+```
+
+#### innerClass
+
+| Type    | String          |
+|---------|-----------------|
+| Default | 'tooltip-inner' |
+
+Adds extra classes to inner tooltips.
+
+Usually used along with [`tooltipClass`](#tooltipclass).
+
+```hbs
+{{ember-tooltip innerClass='hoverhelp__inner'}}
+```
+
+This will create html similar to:
+```html
+<div class="tooltip">
+  <div class="tooltip-arrow"></div>
+  <div class="hoverhelp__inner"><!-- content --></div>
+</div>
 ```
 
 #### Delay

--- a/UPGRADING-3.x.md
+++ b/UPGRADING-3.x.md
@@ -37,24 +37,24 @@ e.g.
 -      {{#tooltip-on-element
 -        class="user-banner__photo__tooltip js-user-photo-tooltip"
 -        enableLazyRendering=true
--        side='right'}}
+-        side="right"}}
 +      {{#ember-tooltip
 +        class="js-user-photo-tooltip"
-+        tooltipClassName="ember-tooltip user-banner__photo__tooltip"
-+        side='right'}}
++        tooltipClass="user-banner__photo__tooltip"
++        side="right"}}
          <img src={{user.photo_url}} alt="User photo" />
 -      {{/tooltip-on-element}}
 +      {{/ember-tooltip}}
 ```
 
-### 3. Update `class` and `tooltipClassName`
+### 3. Update `class` and `tooltipClass`
 
 When specifying `class` with an `ember-tooltip`, this will apply to the tooltip
 wrapper component, but will not contain the actual tooltip content. `class` may
 still be used for targeting tooltips using the `ember-tooltips` test helpers.
 
 For other uses where you're looking to set a class on the actual tooltip used
-for display (e.g. changing styling), use `tooltipClassName`, which will
+for display (e.g. changing styling), use `tooltipClass`, which will
 apply to the `popper.js` tooltip instance in the DOM.
 
 e.g.
@@ -64,7 +64,7 @@ e.g.
 {{ember-tooltip
   text="Hello"
   class="js-my-test-tooltip"
-  tooltipClassName="ember-tooltip tooltip-warning"
+  tooltipClass="tooltip-warning"
 }}
 ```
 

--- a/addon/components/ember-popover.js
+++ b/addon/components/ember-popover.js
@@ -3,7 +3,7 @@ import EmberTooltipBase from 'ember-tooltips/components/ember-tooltip-base';
 
 export default EmberTooltipBase.extend({
   popoverHideDelay: 250,
-  tooltipClassName: 'ember-popover',
+  _tooltipVariantClass: 'ember-popover',
 
   _isMouseInside: false,
 

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -319,7 +319,7 @@ export default Component.extend({
   createTooltip() {
     const target = this.get('target');
     const tooltipBaseClass = this.get('tooltipBaseClass');
-    const tooltipClassName = this.get('tooltipClassName');
+    const tooltipExtraClasses = this.get('tooltipClassName');
 
     const targetTitle = target.title;
 
@@ -331,7 +331,7 @@ export default Component.extend({
       placement: this.get('side'),
       title: '<span></span>',
       trigger: 'manual',
-      template: `<div class="${tooltipBaseClass} ${tooltipClassName} ember-tooltip-effect-${this.get('effect')}" role="tooltip" style="margin:0;margin-${getOppositeSide(this.get('side'))}: ${this.get('spacing')}px;">
+      template: `<div class="${tooltipBaseClass} ${tooltipExtraClasses} ember-tooltip-effect-${this.get('effect')}" role="tooltip" style="margin:0;margin-${getOppositeSide(this.get('side'))}: ${this.get('spacing')}px;">
                    <div class="${tooltipBaseClass}-arrow ember-tooltip-arrow"></div>
                    <div class="${tooltipBaseClass}-inner" id="${this.get('wormholeId')}"></div>
                  </div>`,

--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -76,6 +76,7 @@ export default Component.extend({
   duration: 0,
   effect: 'slide', // Options: fade, slide, none // TODO - make slide work
   event: 'hover', // Options: hover, click, focus, none
+  tooltipBaseClass: 'tooltip',
   tooltipClassName: 'ember-tooltip', /* Custom classes */
   isShown: false,
   text: null,
@@ -317,6 +318,7 @@ export default Component.extend({
 
   createTooltip() {
     const target = this.get('target');
+    const tooltipBaseClass = this.get('tooltipBaseClass');
     const tooltipClassName = this.get('tooltipClassName');
 
     const targetTitle = target.title;
@@ -329,10 +331,10 @@ export default Component.extend({
       placement: this.get('side'),
       title: '<span></span>',
       trigger: 'manual',
-      template: `<div class="tooltip ${tooltipClassName} ember-tooltip-effect-${this.get('effect')}" role="tooltip" style="margin:0;margin-${getOppositeSide(this.get('side'))}:${this.get('spacing')}px;">
-                  <div class="tooltip-arrow ember-tooltip-arrow"></div>
-                  <div class="tooltip-inner" id="${this.get('wormholeId')}"></div>
-                  </div>`,
+      template: `<div class="${tooltipBaseClass} ${tooltipClassName} ember-tooltip-effect-${this.get('effect')}" role="tooltip" style="margin:0;margin-${getOppositeSide(this.get('side'))}: ${this.get('spacing')}px;">
+                   <div class="${tooltipBaseClass}-arrow ember-tooltip-arrow"></div>
+                   <div class="${tooltipBaseClass}-inner" id="${this.get('wormholeId')}"></div>
+                 </div>`,
 
       popperOptions: {
         modifiers: mergeModifiers(

--- a/addon/components/ember-tooltip.js
+++ b/addon/components/ember-tooltip.js
@@ -1,5 +1,5 @@
 import EmberTooltipBase from 'ember-tooltips/components/ember-tooltip-base';
 
 export default EmberTooltipBase.extend({
-
+  _tooltipVariantClass: 'ember-tooltip',
 });

--- a/tests/dummy/app/templates/acceptance.hbs
+++ b/tests/dummy/app/templates/acceptance.hbs
@@ -1,6 +1,6 @@
 <span class="js-test-tooltip-target">
   Tooltip
-  {{#ember-tooltip tooltipClassName="ember-tooltip js-test-tooltip"}}
+  {{#ember-tooltip tooltipClass="js-test-tooltip"}}
     tooltip text
   {{/ember-tooltip}}
 </span>
@@ -9,7 +9,7 @@
 
 <span class="js-test-popover-target">
   Popover
-  {{#ember-popover tooltipClassName="ember-popover js-test-popover"}}
+  {{#ember-popover tooltipClass="js-test-popover"}}
     popover text
   {{/ember-popover}}
 </span>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -23,7 +23,7 @@
 </div>
 
 {{#ember-tooltip
-  tooltipClassName="ember-tooltip logo-tooltip"
+  tooltipClass="logo-tooltip"
   event="none"
   targetId="ember-logo"
   isShown=showLogoTooltip
@@ -160,7 +160,7 @@
 {{#some-component}}
   Show an error
 
-  {{#ember-tooltip tooltipClassName="ember-tooltip tooltip-error"}}
+  {{#ember-tooltip tooltipClass="tooltip-error"}}
     Here is the error!
   {{/ember-tooltip}}
 {{/some-component}}

--- a/tests/dummy/app/templates/many-tooltips.hbs
+++ b/tests/dummy/app/templates/many-tooltips.hbs
@@ -1,7 +1,7 @@
 <div class="tooltip-1-target">
   tooltip 1
 
-  {{#ember-tooltip tooltipClassName="ember-tooltip tooltip-1"}}
+  {{#ember-tooltip tooltipClass="tooltip-1"}}
     tooltip-1!
   {{/ember-tooltip}}
 </div>
@@ -9,72 +9,72 @@
 <div class="tooltip-2-target">
   tooltip 2
 
-  {{#ember-tooltip tooltipClassName="ember-tooltip tooltip-2"}}
+  {{#ember-tooltip tooltipClass="tooltip-2"}}
     Here is the info!
   {{/ember-tooltip}}
 </div>
 
 <div class="tooltip-3-target">
   tooltip 3
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-3" text="tooltip-3"}}
+  {{ember-tooltip tooltipClass="tooltip-3" text="tooltip-3"}}
 </div>
 
 <div class="tooltip-4-target">
   tooltip 4
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-4" text="tooltip-4"}}
+  {{ember-tooltip tooltipClass="tooltip-4" text="tooltip-4"}}
 </div>
 
 <div class="tooltip-5-target">
   tooltip 5
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-5" text="tooltip-5"}}
+  {{ember-tooltip tooltipClass="tooltip-5" text="tooltip-5"}}
 </div>
 
 <div class="tooltip-6-target">
   tooltip 6
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-6" text="tooltip-6"}}
+  {{ember-tooltip tooltipClass="tooltip-6" text="tooltip-6"}}
 </div>
 
 <div class="tooltip-7-target">
   tooltip 7
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-7" text="tooltip-7"}}
+  {{ember-tooltip tooltipClass="tooltip-7" text="tooltip-7"}}
 </div>
 
 <div class="tooltip-8-target">
   tooltip 8
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-8" text="tooltip-8"}}
+  {{ember-tooltip tooltipClass="tooltip-8" text="tooltip-8"}}
 </div>
 
 <div class="tooltip-9-target">
   tooltip 9
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-9" text="tooltip-9"}}
+  {{ember-tooltip tooltipClass="tooltip-9" text="tooltip-9"}}
 </div>
 
 <div class="tooltip-10-target">
   tooltip 10
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-10" text="tooltip-10"}}
+  {{ember-tooltip tooltipClass="tooltip-10" text="tooltip-10"}}
 </div>
 
 <div class="tooltip-11-target">
   tooltip 11
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-11" text="tooltip-11"}}
+  {{ember-tooltip tooltipClass="tooltip-11" text="tooltip-11"}}
 </div>
 
 <div class="tooltip-12-target">
   tooltip 12
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-12" text="tooltip-12"}}
+  {{ember-tooltip tooltipClass="tooltip-12" text="tooltip-12"}}
 </div>
 
 <div class="tooltip-13-target">
   tooltip 13
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-13" text="tooltip-13"}}
+  {{ember-tooltip tooltipClass="tooltip-13" text="tooltip-13"}}
 </div>
 
 <div class="tooltip-14-target">
   tooltip 14
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-14" text="tooltip-14"}}
+  {{ember-tooltip tooltipClass="tooltip-14" text="tooltip-14"}}
 </div>
 
 <div class="tooltip-15-target">
   tooltip 15
-  {{ember-tooltip tooltipClassName="ember-tooltip tooltip-15" text="tooltip-15"}}
+  {{ember-tooltip tooltipClass="tooltip-15" text="tooltip-15"}}
 </div>

--- a/tests/integration/components/delay-on-change-test.js
+++ b/tests/integration/components/delay-on-change-test.js
@@ -17,7 +17,7 @@ module('Integration | Option | delayOnChange', function(hooks) {
     /* Create two tooltips and show one */
 
     await render(hbs`
-      {{ember-tooltip delay=300 delayOnChange=false tooltipClassName='ember-tooltip test-tooltip' text='Hey'}}
+      {{ember-tooltip delay=300 delayOnChange=false tooltipClass='test-tooltip' text='Hey'}}
       {{ember-tooltip delayOnChange=false isShown=true event='none' text='Hi'}}
     `);
 

--- a/tests/integration/components/helpers/find-tooltip-test.js
+++ b/tests/integration/components/helpers/find-tooltip-test.js
@@ -38,10 +38,19 @@ module('Integration | Helpers | findTooltip', function(hooks) {
     assertTooltipRendered(assert, { selector: '.js-tooltip-component-element' });
   });
 
+  // Deprecated. Maintaining until 4.0.0
   test('findTooltip() can find a tooltip based on tooltipClassName passed to the component', async function(assert) {
     assert.expect(1);
 
     await render(hbs`{{ember-tooltip text='hello' tooltipClassName='ember-tooltip js-class-on-the-popper-element' isShown=true}}`);
+
+    assertTooltipRendered(assert, { selector: '.js-class-on-the-popper-element' });
+  });
+
+  test('findTooltip() can find a tooltip based on tooltipClass passed to the component', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{ember-tooltip text='hello' tooltipClass='js-class-on-the-popper-element' isShown=true}}`);
 
     assertTooltipRendered(assert, { selector: '.js-class-on-the-popper-element' });
   });

--- a/tests/integration/components/keydown-test.js
+++ b/tests/integration/components/keydown-test.js
@@ -17,15 +17,15 @@ module('Integration | Component | keydown', function(hooks) {
     /* Create two tooltips and hide one after another with two keydown events */
 
     await render(hbs`
-      {{ember-tooltip isShown=true tooltipClassName='ember-tooltip test-tooltip1' text='I am here'}}
-      {{ember-tooltip isShown=true tooltipClassName='ember-tooltip test-tooltip2' text='I am there'}}
+      {{ember-tooltip isShown=true tooltipClass='test-tooltip1' text='I am here'}}
+      {{ember-tooltip isShown=true tooltipClass='test-tooltip2' text='I am there'}}
     `);
 
     await settled();
 
     assertTooltipVisible(assert, { selector: '.test-tooltip1' });
     assertTooltipVisible(assert, { selector: '.test-tooltip2' });
-    
+
     const { element } = this;
     await triggerKeyEvent(element, 'keydown', 27);
 


### PR DESCRIPTION
Some code bases may have more than one type of tooltip and thus the class of `tooltip` is liable to collide.

We should allow the base class to be updated.

Closes #324 