### PR TITLE
Import popper.js & tooltip.js via AMD, rather than globals

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -1,4 +1,4 @@
-/* global Tooltip */
+import Tooltip from 'tooltip.js';
 import Ember from 'ember';
 import { computed } from '@ember/object';
 import { assign } from '@ember/polyfills';
@@ -499,7 +499,7 @@ export default Component.extend({
       this.set('isShown', false);
       this._dispatchAction('onHide', this);
     }, this.get('_animationDuration'));
-    
+
     this.set('_completeHideTimer', _completeHideTimer);
   },
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -19,8 +19,6 @@ module.exports = function(defaults) {
     with CSS, Javscript, HTML/XML, Handlebars
   */
 
-  app.import('node_modules/popper.js/dist/umd/popper.js');
-  app.import('node_modules/tooltip.js/dist/umd/tooltip.js');
   app.import('vendor/highlight.pack.js', {
     using: [{
       transformation: 'amd',

--- a/index.js
+++ b/index.js
@@ -1,12 +1,26 @@
-'use strict';
+"use strict";
 
 module.exports = {
-  name: require('./package').name,
+  name: require("./package").name,
 
   included: function(app) {
     this._super.included(app);
 
-    app.import(`${this.project.root}/node_modules/popper.js/dist/umd/popper.js`);
-    app.import(`${this.project.root}/node_modules/tooltip.js/dist/umd/tooltip.js`);
+    app.import("node_modules/popper.js/dist/umd/popper.js", {
+      using: [
+        {
+          transformation: "amd",
+          as: "popper.js"
+        }
+      ]
+    });
+    app.import("node_modules/tooltip.js/dist/umd/tooltip.js", {
+      using: [
+        {
+          transformation: "amd",
+          as: "tooltip.js"
+        }
+      ]
+    });
   }
 };


### PR DESCRIPTION
Fixes #318 (though I'm not really sure why. #JustEmberCLIThings) & fixes #323 