### PR TITLE
fix: apply included function with arguments instead of app

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   name: require("./package").name,
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     app.import("node_modules/popper.js/dist/umd/popper.js", {
       using: [


### PR DESCRIPTION
This is the "recommended" way as seen in https://ember-cli.com/extending/#addon-entry-point .

I'm opening this PR as `this._super.included(app)` it causes some issues with ember-decorators and the next ember-cli-typescript version. 
This will prevent others from having to dive in on why this happens if you try to port your addon to use these addons.