### PR TITLE
Allow toggling of popover with isShown even when mouse is still inside element

### DIFF
--- a/addon/components/ember-popover.js
+++ b/addon/components/ember-popover.js
@@ -36,8 +36,14 @@ export default EmberTooltipBase.extend({
       const { target: eventTarget } = event;
       const clickIsOnPopover = eventTarget == _tooltip.popperInstance.popper;
       const clickIsOnTarget = eventTarget == target;
+      const hasHideOnEvent = this.get('hideOn') !== 'none';
+      const hideOnOutsideClick = hasHideOnEvent &&
+        !this.get('_isMouseInside') &&
+        !clickIsOnPopover &&
+        !clickIsOnTarget &&
+        this.get('isShown');
 
-      if (!this.get('_isMouseInside') && !clickIsOnPopover && !clickIsOnTarget) {
+      if (hideOnOutsideClick) {
         this.hide();
       }
     }, document);
@@ -89,7 +95,7 @@ export default EmberTooltipBase.extend({
     }, popover);
 
     this._addEventListener('focusout', () => {
-      if (!this.get('_isMouseInside')) {
+      if (!this.get('_isMouseInside') && this.get('isShown')) {
         this.hide();
       }
     }, popover);
@@ -106,7 +112,7 @@ export default EmberTooltipBase.extend({
     cancel(this.get('_showTimer'));
 
     later(() => {
-      if (!this.get('_isMouseInside')) {
+      if (!this.get('_isMouseInside') || !this.get('isShown')) {
         this._hideTooltip();
       }
     }, +this.get('popoverHideDelay'));

--- a/addon/components/ember-popover.js
+++ b/addon/components/ember-popover.js
@@ -36,7 +36,7 @@ export default EmberTooltipBase.extend({
       const { target: eventTarget } = event;
       const clickIsOnPopover = eventTarget == _tooltip.popperInstance.popper;
       const clickIsOnTarget = eventTarget == target;
-      const hasHideOnEvent = this.get('hideOn') !== 'none';
+      const hasHideOnEvent = this.get('hideOn') && this.get('hideOn') !== 'none';
       const hideOnOutsideClick = hasHideOnEvent &&
         !this.get('_isMouseInside') &&
         !clickIsOnPopover &&

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -5,6 +5,7 @@ import { cancel, later, scheduleOnce } from '@ember/runloop';
 export default Controller.extend({
   asyncContent: null,
   showTooltips: false,
+  showToggleablePopover: false,
 
   actions: {
     setAsyncContent() {
@@ -15,6 +16,10 @@ export default Controller.extend({
         }, 2000);
       });
     },
+
+    togglePopover() {
+      this.toggleProperty('showToggleablePopover');
+    }
   },
 
   init() {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -55,6 +55,7 @@
     <li><a href="#styling">Using custom styling</a></li>
     <li><a href="#async">Using async content</a></li>
     <li><a href="#popover">Using a popover instead of a tooltip</a></li>
+    <li><a href="#programatic-toggle">Toggling programatically</a></li>
     <li><a href="#inline">Using in inline form</a></li>
   </ul>
 </div>
@@ -215,6 +216,26 @@
 </div>
 
 <div class="page-content">
+  <h3 id="programatic-toggle">Toggling programatically</h3>
+
+{{!-- BEGIN-SNIPPET programatic-toggle --}}
+{{#some-component}}
+  <div onClick={{action "togglePopover"}} {{! template-lint-disable no-invalid-interactive }}>
+    Click me to toggle popover
+  </div>
+
+  {{#ember-popover isShown=showToggleablePopover event="none" class="test-programatic-toggle-example"}}
+    <h3>More info</h3>
+    <p>Here is more information!</p>
+  {{/ember-popover}}
+{{/some-component}}
+{{!-- END-SNIPPET --}}
+
+  {{code-snippet name="programatic-toggle.hbs"}}
+
+</div>
+
+<div class="page-content gray">
   <h3 id="inline">Using in inline form</h3>
 
 {{!-- BEGIN-SNIPPET inline-content --}}

--- a/tests/integration/components/is-shown-test.js
+++ b/tests/integration/components/is-shown-test.js
@@ -1,55 +1,80 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { find, render, settled, triggerEvent } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
 import {
   assertTooltipNotVisible,
-  assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+  assertTooltipVisible
+} from "ember-tooltips/test-support";
 
-module('Integration | Option | isShown', function(hooks) {
+module("Integration | Option | isShown", function(hooks) {
   setupRenderingTest(hooks);
 
-  test('ember-tooltip toggles with isShown', async function(assert) {
-
+  test("ember-tooltip toggles with isShown", async function(assert) {
     assert.expect(3);
 
-    this.set('showTooltip', true);
+    this.set("showTooltip", true);
 
     await render(hbs`{{ember-tooltip isShown=showTooltip}}`);
 
     assertTooltipVisible(assert);
 
-    this.set('showTooltip', false);
+    this.set("showTooltip", false);
 
     await settled();
 
     assertTooltipNotVisible(assert);
 
-    this.set('showTooltip', true);
+    this.set("showTooltip", true);
 
     await settled();
 
     assertTooltipVisible(assert);
   });
 
-  test('ember-popover toggles with isShown', async function(assert) {
-
+  test("ember-popover toggles with isShown", async function(assert) {
     assert.expect(3);
 
-    this.set('showTooltip', true);
+    this.set("showTooltip", true);
 
     await render(hbs`{{ember-popover isShown=showTooltip}}`);
 
     assertTooltipVisible(assert);
 
-    this.set('showTooltip', false);
+    this.set("showTooltip", false);
 
     await settled();
 
     assertTooltipNotVisible(assert);
 
-    this.set('showTooltip', true);
+    this.set("showTooltip", true);
+
+    await settled();
+
+    assertTooltipVisible(assert);
+  });
+
+  test("ember-popover toggles with isShown even when mouse is inside popover", async function(assert) {
+    assert.expect(3);
+
+    this.set("showTooltip", true);
+
+    await render(
+      hbs`{{ember-popover isShown=showTooltip class="js-test-popover"}}`
+    );
+
+    assertTooltipVisible(assert);
+
+    const popoverTarget = find(".js-test-popover");
+    await triggerEvent(popoverTarget, "mouseenter");
+
+    this.set("showTooltip", false);
+
+    await settled();
+
+    assertTooltipNotVisible(assert);
+
+    this.set("showTooltip", true);
 
     await settled();
 

--- a/tests/integration/components/popover/actions-test.js
+++ b/tests/integration/components/popover/actions-test.js
@@ -1,0 +1,120 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Popover | Option | actions', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
+
+  test('ember-popover calls lifecycle actions', async function(assert) {
+
+    assert.expect(11);
+
+    const actionsCalledHash = {
+      onRenderFoo: 0,
+      onShowBar: 0,
+      onHideBaz: 0,
+      onDestroyFubar: 0,
+    };
+
+    /* Setup the actions and handlers... */
+
+    Object.keys(actionsCalledHash).forEach((action) => {
+      this.set(action, () => {
+        assert.ok(true, `Should call ${action}`);
+
+        /* Count the calls... */
+
+        actionsCalledHash[action]++;
+      });
+    });
+
+    /* Now, let's go through the component lifecycle */
+
+    await render(hbs`
+      {{#unless destroyTooltip}}
+        {{ember-popover
+          onRender=(action onRenderFoo)
+          onShow=(action onShowBar)
+          onHide=(action onHideBaz)
+          onDestroy=(action onDestroyFubar)
+        }}
+      {{/unless}}
+    `);
+
+    const { element } = this;
+
+    assert.equal(actionsCalledHash.onRenderFoo, 0,
+      'Should not have called render');
+
+    /* Check render */
+
+    await triggerEvent(element, 'mouseenter');
+
+    assert.equal(actionsCalledHash.onRenderFoo, 1,
+      'Should have called render');
+
+    /* Check show */
+
+    assert.equal(actionsCalledHash.onShowBar, 1,
+      'Should have called show');
+
+    assert.equal(actionsCalledHash.onHideBaz, 0,
+      'Should not have called hide');
+
+    await triggerEvent(element, 'mouseleave');
+
+    assert.equal(actionsCalledHash.onHideBaz, 1,
+      'Should have called hide');
+
+    await triggerEvent(document.body, 'click');
+    await triggerEvent(document.body, 'click');
+    await triggerEvent(document.body, 'click');
+    await triggerEvent(document.body, 'click');
+
+    assert.equal(actionsCalledHash.onHideBaz, 1,
+      'Should not have triggered additional onHide calls');
+
+    /* Check destroy */
+
+    this.set('destroyTooltip', true);
+
+    assert.equal(actionsCalledHash.onDestroyFubar, 1,
+      'Should have called destroy');
+
+  });
+
+  test('ember-popover supports lifecycle closure actions with multiple arguments', async function(assert) {
+
+    /* Closure actions allow you to pass multiple parameters
+    when you declare the action variable. This test covers that case.
+    */
+
+    assert.expect(1);
+
+    let onRenderPassword;
+
+    this.actions.onRenderFoo = (trickPassword, realPassword) => {
+      onRenderPassword = realPassword;
+    };
+
+    await render(hbs`
+      {{ember-popover
+        onRender=(action 'onRenderFoo' 'trick password' 'real password')
+      }}
+    `);
+
+    const { element } = this;
+
+    await triggerEvent(element, 'mouseenter');
+
+    assert.equal(onRenderPassword, 'real password',
+      'popover should support closure actions with multiple arguments');
+
+  });
+});

--- a/tests/integration/components/popover/click-test.js
+++ b/tests/integration/components/popover/click-test.js
@@ -152,4 +152,49 @@ module('Integration | Option | click', function(hooks) {
 
     assertTooltipNotVisible(assert);
   });
+
+  test('Popover: click target, click popover, click elsewhere (event == "none")', async function(assert) {
+
+    assert.expect(5);
+
+    this.set('showingPopover', false);
+
+    this.togglePopover = () => {
+      this.set('showingPopover', !this.get('showingPopover'));
+    };
+
+    await render(hbs`
+      <div class="elsewhere">
+        <div class="target" onClick={{action togglePopover}}>
+          {{ember-popover isShown=showingPopover event='none' popoverHideDelay=0}}
+        </div>
+      </div>
+    `);
+
+    assertTooltipNotRendered(assert);
+
+    await click('.target');
+
+    assertTooltipVisible(assert);
+
+    /* Mimic user's cursor entering popover and clicking it */
+
+    await triggerEvent('.ember-popover', 'mouseenter');
+
+    await click('.ember-popover');
+
+    assertTooltipVisible(assert);
+
+    /* Mimic user's cursor leaving popover and clicking away from it */
+
+    await triggerEvent('.ember-popover', 'mouseleave');
+
+    await click('.elsewhere');
+
+    assertTooltipVisible(assert);
+
+    await click('.target');
+
+    assertTooltipNotVisible(assert);
+  });
 });

--- a/tests/integration/components/popover/click-test.js
+++ b/tests/integration/components/popover/click-test.js
@@ -153,48 +153,54 @@ module('Integration | Option | click', function(hooks) {
     assertTooltipNotVisible(assert);
   });
 
-  test('Popover: click target, click popover, click elsewhere (event == "none")', async function(assert) {
+  [
+    null,
+    "none"
+  ].forEach((event) => {
+    test(`Popover: click target, click popover, click elsewhere (event == ${event})`, async function(assert) {
 
-    assert.expect(5);
+      assert.expect(5);
 
-    this.set('showingPopover', false);
+      this.set('showingPopover', false);
+      this.set('event', event);
 
-    this.togglePopover = () => {
-      this.set('showingPopover', !this.get('showingPopover'));
-    };
+      this.togglePopover = () => {
+        this.set('showingPopover', !this.get('showingPopover'));
+      };
 
-    await render(hbs`
-      <div class="elsewhere">
-        <div class="target" onClick={{action togglePopover}}>
-          {{ember-popover isShown=showingPopover event='none' popoverHideDelay=0}}
+      await render(hbs`
+        <div class="elsewhere">
+          <div class="target" onClick={{action togglePopover}}>
+            {{ember-popover isShown=showingPopover event=event popoverHideDelay=0}}
+          </div>
         </div>
-      </div>
-    `);
+      `);
 
-    assertTooltipNotRendered(assert);
+      assertTooltipNotRendered(assert);
 
-    await click('.target');
+      await click('.target');
 
-    assertTooltipVisible(assert);
+      assertTooltipVisible(assert);
 
-    /* Mimic user's cursor entering popover and clicking it */
+      /* Mimic user's cursor entering popover and clicking it */
 
-    await triggerEvent('.ember-popover', 'mouseenter');
+      await triggerEvent('.ember-popover', 'mouseenter');
 
-    await click('.ember-popover');
+      await click('.ember-popover');
 
-    assertTooltipVisible(assert);
+      assertTooltipVisible(assert);
 
-    /* Mimic user's cursor leaving popover and clicking away from it */
+      /* Mimic user's cursor leaving popover and clicking away from it */
 
-    await triggerEvent('.ember-popover', 'mouseleave');
+      await triggerEvent('.ember-popover', 'mouseleave');
 
-    await click('.elsewhere');
+      await click('.elsewhere');
 
-    assertTooltipVisible(assert);
+      assertTooltipVisible(assert);
 
-    await click('.target');
+      await click('.target');
 
-    assertTooltipNotVisible(assert);
-  });
+      assertTooltipNotVisible(assert);
+    });
+  })
 });


### PR DESCRIPTION
In the case where `event` is set to `"none"`, we want to avoid caring
about the state of the mouse and let `isShown` control whether the
popover is showing, just like how it works with tooltips.

Fixes #335, (Also fixes #333 by checking for `isShown` in the click handler)