### PR TITLE
Remove animation frame timer check preventing proper spacing update

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -370,7 +370,7 @@ export default Component.extend({
   },
 
   setSpacing() {
-    if (this._spacingRequestId || !this.get('isShown') || this.get('isDestroying')) {
+    if (!this.get('isShown') || this.get('isDestroying')) {
       return;
     }
 


### PR DESCRIPTION
Fixes #337. Thanks to @kstinson14 for investigating. Simply removing the check for a rAF ID seems to fix the problem while also not having any apparent impact on performance, from what I could tell through profiling.