### PR TITLE
Avoid rendering content into DOM until popper element created

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -1,5 +1,6 @@
 import Tooltip from 'tooltip.js';
 import Ember from 'ember';
+import { getOwner } from '@ember/application';
 import { computed } from '@ember/object';
 import { assign } from '@ember/polyfills';
 import { run } from '@ember/runloop';
@@ -157,6 +158,19 @@ export default Component.extend({
 
   wormholeId: computed('elementId', function() {
     return `${this.get('elementId')}-wormhole`;
+  }),
+
+  _fastboot: computed(function() {
+    let owner = getOwner(this);
+    return owner.lookup('service:fastboot');
+  }),
+
+  _shouldRenderContent: computed(
+    '_fastboot.isFastBoot',
+    '_awaitingTooltipElementRendered',
+    function() {
+    return this.get('_fastboot.isFastBoot') ||
+      !this.get('_awaitingTooltipElementRendered');
   }),
 
   _awaitingTooltipElementRendered: true,

--- a/addon/templates/components/ember-tooltip-base.hbs
+++ b/addon/templates/components/ember-tooltip-base.hbs
@@ -1,9 +1,11 @@
 {{#ember-wormhole to=wormholeId renderInPlace=_awaitingTooltipElementRendered}}
   <div>
-    {{#if (hasBlock)}}
-      {{yield this}}
-    {{else}}
-      {{text}}
+    {{#if _shouldRenderContent}}
+      {{#if (hasBlock)}}
+        {{yield this}}
+      {{else}}
+        {{text}}
+      {{/if}}
     {{/if}}
   </div>
 {{/ember-wormhole}}


### PR DESCRIPTION
Fixes #341 and more adequately addresses concerns from #340, #330 without requiring the user to check `isShown`. Bug was introduced by me in b83580c43689d922cb53e002479781332f9be4ef, and broke a promise about how enableLazyRendering in 2.x would essentially be the default and behave the same way.

However, the fastboot tests established that the content would be rendered into the DOM in fastboot mode, so this preserves that behavior.

This may break folks with existing tests depending on rendered content, so it seems like it may warrant a major version bump. But I can also see it being framed as a fix for a bug introduced in the betas, and warrant being a minor version bump. /cc @sir-dunxalot