### PR TITLE
Refactor jquery in tests

### DIFF
--- a/addon-test-support/dom/assertions/assert-tooltip-content.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-content.js
@@ -1,0 +1,18 @@
+import { assert as emberAssert } from '@ember/debug';
+import { isNone } from '@ember/utils';
+import { findTooltip } from 'ember-tooltips/test-support/dom';
+
+export default function assertTooltipContent(assert, options = {}) {
+  const { contentString, selector } = options;
+
+  if (isNone(contentString)) {
+    emberAssert('You must specify a contentString property in the options parameter');
+  }
+
+  const tooltip = findTooltip(selector);
+  const tooltipContent = tooltip.innerText.trim();
+
+  assert.equal(tooltipContent, contentString,
+    `Content of tooltip (${tooltipContent}) matched expected (${contentString})`);
+
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-not-rendered.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-not-rendered.js
@@ -1,0 +1,8 @@
+import { findTooltip } from 'ember-tooltips/test-support/dom';
+
+export default function assertTooltipNotRendered(assert, options = {}) {
+  const { selector } = options;
+  const tooltip = findTooltip(selector);
+
+  assert.notOk(tooltip, 'assertTooltipNotRendered(): the ember-tooltip should not be rendered');
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-not-visible.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-not-visible.js
@@ -1,0 +1,11 @@
+import { findTooltip } from 'ember-tooltips/test-support/dom';
+
+export default function assertTooltipNotVisible(assert, options = {}) {
+  const { selector } = options;
+  const tooltip = findTooltip(selector);
+  const ariaHidden = tooltip.getAttribute('aria-hidden');
+
+  assert.ok(ariaHidden === 'true',
+    `assertTooltipNotVisible(): the ember-tooltip shouldn't be visible:
+      aria-hidden = ${ariaHidden}`);
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-rendered.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-rendered.js
@@ -1,0 +1,8 @@
+import { findTooltip } from 'ember-tooltips/test-support/dom';
+
+export default function assertTooltipRendered(assert, options = {}) {
+  const { selector } = options;
+  const tooltip = findTooltip(selector);
+
+  assert.ok(tooltip, 'assertTooltipRendered(): the ember-tooltip should be rendered');
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-side.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-side.js
@@ -1,0 +1,18 @@
+import { getPositionDifferences } from 'ember-tooltips/test-support/dom';
+import { validateSide } from 'ember-tooltips/test-support';
+
+export default function assertTooltipSide(assert, options = {}) {
+  const { side } = options;
+
+  validateSide(side);
+
+  const { expectedGreaterDistance, expectedLesserDistance } = getPositionDifferences(options);
+
+  /* When the side is top or left, the greater number
+  is the target's position. Thus, we check that the
+  target's position is greater than the tooltip's
+  position. */
+
+  assert.ok(expectedGreaterDistance > expectedLesserDistance,
+    `Tooltip should be on the ${side} side of the target`);
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-spacing.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-spacing.js
@@ -1,0 +1,29 @@
+import { assert as emberAssert } from '@ember/debug';
+import { getPositionDifferences } from 'ember-tooltips/test-support/dom';
+import { validateSide } from 'ember-tooltips/test-support';
+
+export default function assertTooltipSpacing(assert, options) {
+  const { side, spacing } = options;
+
+  validateSide(side, 'assertTooltipSpacing');
+
+  if (typeof spacing !== 'number') {
+    emberAssert(`You must pass spacing as a number like assertTooltipSpacing(assert, { side: 'top', spacing: 10 });`);
+  }
+
+  const { expectedGreaterDistance, expectedLesserDistance } = getPositionDifferences(options);
+  const actualSpacing = Math.round(expectedGreaterDistance - expectedLesserDistance);
+
+  /* When the side is top or left, the greater number
+  is the target's position. Thus, we check that the
+  target's position is greater than the tooltip's
+  position. */
+
+  const isSideCorrect = expectedGreaterDistance > expectedLesserDistance;
+  const isSpacingCorrect = actualSpacing === spacing;
+
+  assert.ok(isSideCorrect && isSpacingCorrect,
+    `assertTooltipSpacing(): the tooltip should be in the correct position:
+        - Tooltip should be on the ${side} side of the target: ${isSideCorrect}.
+        - On the ${side} side of the target, the tooltip should be ${spacing}px from the target but it was ${actualSpacing}px`);
+}

--- a/addon-test-support/dom/assertions/assert-tooltip-visible.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-visible.js
@@ -1,0 +1,11 @@
+import { findTooltip } from 'ember-tooltips/test-support/dom';
+
+export default function assertTooltipVisible(assert, options = {}) {
+  const { selector } = options;
+  const tooltip = findTooltip(selector);
+  const ariaHidden = tooltip.getAttribute('aria-hidden');
+
+  assert.ok(ariaHidden === 'false',
+    `assertTooltipVisible(): the ember-tooltip should be visible:
+      aria-hidden = ${ariaHidden}`);
+}

--- a/addon-test-support/dom/assertions/index.js
+++ b/addon-test-support/dom/assertions/index.js
@@ -1,0 +1,7 @@
+export { default as assertTooltipContent } from './assert-tooltip-content';
+export { default as assertTooltipNotRendered } from './assert-tooltip-not-rendered';
+export { default as assertTooltipNotVisible } from './assert-tooltip-not-visible';
+export { default as assertTooltipRendered } from './assert-tooltip-rendered';
+export { default as assertTooltipSide } from './assert-tooltip-side';
+export { default as assertTooltipSpacing } from './assert-tooltip-spacing';
+export { default as assertTooltipVisible } from './assert-tooltip-visible';

--- a/addon-test-support/dom/find-tooltip-target.js
+++ b/addon-test-support/dom/find-tooltip-target.js
@@ -1,0 +1,18 @@
+export function findTooltipTarget(selector) {
+  if (!selector) { // In case of passing null, undefined, etc
+    selector = '.ember-tooltip-target, .ember-popover-target';
+  }
+
+  const { body } = document;
+  const tooltipTarget = body.querySelectorAll(selector);
+
+  if (tooltipTarget.length === 0) {
+    throw new Error('ember-tooltips/test-support/dom/find-tooltip-target: No tooltip targets were found.');
+  } else if (tooltipTarget.length > 1) {
+    throw new Error('ember-tooltips/test-support/dom/find-tooltip-target: Multiple tooltip targets were found. Please provide an {option.targetSelector = ".specific-tooltip-target-class"}');
+  }
+
+  return tooltipTarget[0];
+}
+
+export default findTooltipTarget;

--- a/addon-test-support/dom/find-tooltip.js
+++ b/addon-test-support/dom/find-tooltip.js
@@ -1,0 +1,51 @@
+export function findTooltip(selectorOrElement, { targetSelector, multiple = false } = {}) {
+  if (!selectorOrElement) { // In case of passing null, undefined, etc
+    selectorOrElement = '.ember-tooltip, .ember-popover';
+  }
+
+  /* We querySelect tooltips from body instead of using ember-test-helper's
+  find() method because tooltips and popovers are often rendered as
+  children of <body> instead of children of the targetElement */
+
+  const { body } = document;
+  let tooltips = typeof selectorOrElement === 'string' ? body.querySelectorAll(selectorOrElement) : [selectorOrElement];
+
+  tooltips = [].slice.call(tooltips).map((tooltip) => getActualTooltip(tooltip, targetSelector)).filter((el) => el);
+
+  if (tooltips.length > 1) {
+    console.warn(`ember-tooltips/test-support/dom/find-tooltip: Multiple tooltips were found. Consider passing a selector '.specific-tooltip-class'`);
+  }
+
+  if (multiple) {
+    return tooltips;
+  }
+
+  let tooltip = tooltips[0];
+
+  if (tooltip && !tooltip.classList.contains('ember-tooltip') && !tooltip.classList.contains('ember-popover')) {
+    throw new Error(`getTooltipFromBody(): returned an element that is not a tooltip`);
+  }
+
+  return tooltip;
+}
+
+export default findTooltip;
+
+function getActualTooltip(tooltip, targetSelector) {
+  if (tooltip && tooltip.classList.contains('ember-tooltip-base')) {
+    /* If what we find is the actually the tooltip component's element, we can
+     * look up the intended tooltip by the element referenced by its target
+     * element's aria-describedby attribute.
+     */
+    const target = tooltip.closest('.ember-tooltip-target, .ember-popover-target');
+
+    // If a targetSelector is specified, filter by it
+    if (!target || (targetSelector && !target.matches(targetSelector))) {
+      return null;
+    }
+
+    tooltip = document.body.querySelector(`#${target.getAttribute('aria-describedby')}`);
+  }
+
+  return tooltip;
+}

--- a/addon-test-support/dom/get-position-differences.js
+++ b/addon-test-support/dom/get-position-differences.js
@@ -1,0 +1,61 @@
+import { getOppositeSide } from 'ember-tooltips/test-support/utils';
+import { findTooltip } from './find-tooltip';
+import { findTooltipTarget } from './find-tooltip-target';
+
+/**
+ @method getPositionDifferences
+ @param String side The side the tooltip should be on relative to the target
+
+ Given a side, which represents the side of the target that
+ the tooltip should render, this method identifies whether
+ the tooltip or the target should be further away from the
+ top left of the window.
+
+ For example, if the side is 'top' then the target should
+ be further away from the top left of the window than the
+ tooltip because the tooltip should render above the target.
+
+ If the side is 'right' then the tooltip should be further
+ away from the top left of the window than the target
+ because the tooltip should render to the right of the
+ target.
+
+ This method then returns an object with two numbers:
+
+ - `expectedGreaterDistance` (expected greater number given the side)
+ - `expectedLesserDistance` (expected lesser number given the side)
+
+ These numbers can be used for calculations like determining
+ whether a tooltip is on the correct side of the target or
+ determining whether a tooltip is the correct distance from
+ the target on the given side.
+ */
+
+export function getPositionDifferences(options = {}) {
+  const { targetPosition, tooltipPosition } = getTooltipAndTargetPosition(options);
+  const { side } = options;
+
+  const distanceToTarget = targetPosition[side];
+  const distanceToTooltip = tooltipPosition[getOppositeSide(side)];
+  const shouldTooltipBeCloserThanTarget = side === 'top' || side === 'left';
+  const expectedGreaterDistance = shouldTooltipBeCloserThanTarget ? distanceToTarget : distanceToTooltip;
+  const expectedLesserDistance = shouldTooltipBeCloserThanTarget ? distanceToTooltip : distanceToTarget;
+
+  return { expectedGreaterDistance, expectedLesserDistance };
+}
+
+export function getTooltipAndTargetPosition(options = {}) {
+  const { selector, targetSelector } = options;
+  const target = findTooltipTarget(targetSelector);
+  const tooltip = findTooltip(selector, { targetSelector });
+
+  const targetPosition = target.getBoundingClientRect();
+  const tooltipPosition = tooltip.getBoundingClientRect();
+
+  return {
+    targetPosition,
+    tooltipPosition
+  };
+}
+
+export default getPositionDifferences;

--- a/addon-test-support/dom/index.js
+++ b/addon-test-support/dom/index.js
@@ -1,0 +1,3 @@
+export { default as findTooltipTarget } from './find-tooltip-target';
+export { default as findTooltip } from './find-tooltip';
+export { default as getPositionDifferences } from './get-position-differences';

--- a/addon-test-support/utils/get-opposite-side.js
+++ b/addon-test-support/utils/get-opposite-side.js
@@ -1,4 +1,4 @@
-export default function getOppositeSide(side) {
+export function getOppositeSide(side) {
   switch (side) {
     case 'top': return 'bottom';
     case 'right': return 'left';
@@ -6,3 +6,5 @@ export default function getOppositeSide(side) {
     case 'left': return 'right';
   }
 }
+
+export default getOppositeSide;

--- a/addon-test-support/utils/index.js
+++ b/addon-test-support/utils/index.js
@@ -1,0 +1,2 @@
+export { default as validateSide } from './validate-side';
+export { default as getOppositeSide } from './get-opposite-side';

--- a/addon-test-support/utils/validate-side.js
+++ b/addon-test-support/utils/validate-side.js
@@ -1,6 +1,6 @@
 import { assert as emberAssert } from '@ember/debug';
 
-export default function validateSide(side, testHelper = 'assertTooltipSide') {
+export function validateSide(side, testHelper = 'assertTooltipSide') {
   const sideIsValid = (
     side === 'top' ||
     side === 'right' ||
@@ -15,3 +15,5 @@ export default function validateSide(side, testHelper = 'assertTooltipSide') {
     emberAssert(`You must pass side like ${testHelper}(assert, { side: 'top' }); Valid options for side are top, right, bottom, and left.`);
   }
 }
+
+export default validateSide;

--- a/tests/acceptance/acceptance-test.js
+++ b/tests/acceptance/acceptance-test.js
@@ -1,14 +1,13 @@
 import { settled, triggerEvent, visit } from '@ember/test-helpers';
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   assertTooltipNotRendered,
   assertTooltipRendered,
   assertTooltipNotVisible,
-  findTooltip,
-  assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+  assertTooltipVisible
+} from 'ember-tooltips/test-support/dom/assertions';
+import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 module('Acceptance | acceptance', function(hooks) {
   setupApplicationTest(hooks);
@@ -20,13 +19,13 @@ module('Acceptance | acceptance', function(hooks) {
 
     assertTooltipNotRendered(assert);
 
-    const $tooltipTarget = $('.js-test-tooltip-target');
-    const [ tooltipTarget ] = $tooltipTarget;
+    const tooltipTargets = document.querySelectorAll('.js-test-tooltip-target');
+    const tooltipTarget = tooltipTargets[0];
     const tooltipOptions = {
-      selector: '.js-test-tooltip',
+      selector: '.js-test-tooltip'
     };
 
-    assert.equal($tooltipTarget.length, 1, 'there should be one $tooltipTarget');
+    assert.equal(tooltipTargets.length, 1, 'there should be one tooltipTarget');
 
     assertTooltipNotRendered(assert, tooltipOptions);
 
@@ -42,13 +41,13 @@ module('Acceptance | acceptance', function(hooks) {
 
     assertTooltipNotVisible(assert, tooltipOptions);
 
-    const $popoverTarget = $('.js-test-popover-target');
-    const [ popoverTarget ] = $popoverTarget;
+    const popoverTargets = document.querySelectorAll('.js-test-popover-target');
+    const popoverTarget = popoverTargets[0];
     const popoverOptions = {
-      selector: '.js-test-popover',
+      selector: '.js-test-popover'
     };
 
-    assert.equal($popoverTarget.length, 1, 'there should be one $popoverTarget');
+    assert.equal(popoverTargets.length, 1, 'there should be one popoverTarget');
 
     assertTooltipNotRendered(assert, popoverOptions);
 
@@ -64,7 +63,7 @@ module('Acceptance | acceptance', function(hooks) {
 
     assertTooltipNotVisible(assert, popoverOptions);
 
-    assert.equal(findTooltip().length, 2,
-        'There should only be 2 tooltips or popovers rendered');
+    assert.equal(findTooltip(null, { multiple: true }).length, 2,
+      'There should only be 2 tooltips or popovers rendered');
   });
 });

--- a/tests/acceptance/many-tooltips-test.js
+++ b/tests/acceptance/many-tooltips-test.js
@@ -4,14 +4,13 @@ import {
   triggerEvent,
   visit
 } from '@ember/test-helpers';
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   assertTooltipNotRendered,
   assertTooltipRendered,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Acceptance | many-tooltips', function(hooks) {
   setupApplicationTest(hooks);
@@ -30,15 +29,14 @@ module('Acceptance | many-tooltips', function(hooks) {
     }, []);
 
     for (const tooltip of tooltips) {
-      const $tooltipTarget = $(`${tooltip}-target`);
-      const [ tooltipTarget ] = $tooltipTarget;
+      const tooltipTarget = document.querySelector(`${tooltip}-target`);
       const tooltipOptions = {
         selector: tooltip,
       };
 
-      assert.equal($tooltipTarget.length, 1, 'there should be one $tooltipTarget');
+      assert.ok(tooltipTarget, 'there should be one $tooltipTarget');
       assertTooltipNotRendered(assert, tooltipOptions);
-      await triggerEvent(tooltipTarget, 'mouseenter')
+      await triggerEvent(tooltipTarget, 'mouseenter');
       assertTooltipRendered(assert, tooltipOptions);
       assertTooltipVisible(assert, tooltipOptions);
     }

--- a/tests/integration/components/compatibility/ember-line-clamp-test.js
+++ b/tests/integration/components/compatibility/ember-line-clamp-test.js
@@ -4,7 +4,7 @@ import { render, triggerEvent } from '@ember/test-helpers';
 import {
   assertTooltipNotRendered,
 	assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Compatibility | ember-line-clamp', function(hooks) {

--- a/tests/integration/components/container-test.js
+++ b/tests/integration/components/container-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   findTooltip,
   findTooltipTarget,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom';
 
 module('Integration | Option | popperContainer', function(hooks) {
   setupRenderingTest(hooks);
@@ -17,10 +17,10 @@ module('Integration | Option | popperContainer', function(hooks) {
       </div>
     `);
     const expectedContainer = this.element;
-    const [ target ] = findTooltipTarget();
+    const target = findTooltipTarget();
     await triggerEvent(target, 'mouseenter');
     const tooltip = findTooltip();
-    assert.equal(tooltip.parent()[0], expectedContainer,
+    assert.equal(tooltip.parentElement, expectedContainer,
       'The tooltip should be a sibling of its target');
   });
 
@@ -32,10 +32,10 @@ module('Integration | Option | popperContainer', function(hooks) {
       </div>
     `);
     const expectedContainer = find('#tooltip-container');
-    const [ target ] = findTooltipTarget();
+    const target = findTooltipTarget();
     await triggerEvent(target, 'mouseenter');
     const tooltip = findTooltip();
-    assert.equal(tooltip.parent()[0], expectedContainer,
+    assert.equal(tooltip.parentElement, expectedContainer,
       'The element identified by the popperContainer attribute should be the tooltip parent');
   });
 });

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipContent,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | content', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/delay-on-change-test.js
+++ b/tests/integration/components/delay-on-change-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotRendered,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | delayOnChange', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/delay-test.js
+++ b/tests/integration/components/delay-test.js
@@ -8,7 +8,7 @@ import {
   assertTooltipNotRendered,
   assertTooltipNotVisible,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 async function testTooltipDelay(assert, template) {
 

--- a/tests/integration/components/duration-test.js
+++ b/tests/integration/components/duration-test.js
@@ -7,7 +7,7 @@ import {
   assertTooltipNotRendered,
   assertTooltipNotVisible,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | duration', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/effect-test.js
+++ b/tests/integration/components/effect-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   findTooltip,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom';
 
 module('Integration | Component | tooltip on element', function(hooks) {
   setupRenderingTest(hooks);
@@ -18,9 +18,9 @@ module('Integration | Component | tooltip on element', function(hooks) {
 
       await render(hbs`{{ember-tooltip effect=effect isShown=true}}`);
 
-      const $tooltip = findTooltip();
+      const tooltip = findTooltip();
 
-      assert.ok($tooltip.hasClass(`ember-tooltip-effect-${effect}`),
+      assert.ok(tooltip.classList.contains(`ember-tooltip-effect-${effect}`),
         `the tooltip should have the ${effect} effect class`);
 
     });

--- a/tests/integration/components/ember-tooltip-test.js
+++ b/tests/integration/components/ember-tooltip-test.js
@@ -5,9 +5,9 @@ import { render, triggerEvent } from '@ember/test-helpers';
 import {
   assertTooltipContent,
   assertTooltipRendered,
-  assertTooltipNotRendered,
-  findTooltipTarget,
-} from 'ember-tooltips/test-support';
+  assertTooltipNotRendered
+} from 'ember-tooltips/test-support/dom/assertions';
+import { findTooltipTarget } from 'ember-tooltips/test-support/dom';
 
 module('Integration | Component | ember-tooltip', function(hooks) {
   setupRenderingTest(hooks);
@@ -29,7 +29,7 @@ module('Integration | Component | ember-tooltip', function(hooks) {
     assertTooltipRendered(assert);
 
     assertTooltipContent(assert, {
-      contentString: 'template block text',
+      contentString: 'template block text'
     });
   });
 
@@ -49,14 +49,14 @@ module('Integration | Component | ember-tooltip', function(hooks) {
 
     await triggerEvent('.target', 'mouseenter');
 
-    const $tooltipTarget = findTooltipTarget();
-    const describedBy = $tooltipTarget.attr('aria-describedby');
+    const tooltipTarget = findTooltipTarget();
+    const describedBy = tooltipTarget.getAttribute('aria-describedby');
 
     /* Whatever the target is 'described by' should be a tooltip with our expected content from the template above */
 
     assertTooltipContent(assert, {
       selector: `#${describedBy}`,
-      contentString: 'Some info in a tooltip.',
+      contentString: 'Some info in a tooltip.'
     });
 
     assert.equal(describedBy.indexOf('#'), '-1');

--- a/tests/integration/components/event-test.js
+++ b/tests/integration/components/event-test.js
@@ -6,7 +6,7 @@ import {
   assertTooltipNotVisible,
   assertTooltipNotRendered,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | event', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/helpers/dom/find-tooltip-test.js
+++ b/tests/integration/components/helpers/dom/find-tooltip-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  assertTooltipNotVisible,
+  assertTooltipVisible,
+  assertTooltipNotRendered,
+  assertTooltipRendered,
+} from 'ember-tooltips/test-support/dom/assertions';
+
+module('Integration | Helpers | dom | findTooltip', function(hooks) {
+  setupRenderingTest(hooks);
+
+  [assertTooltipRendered, assertTooltipNotVisible, assertTooltipVisible].forEach(function(helperInstance) {
+    test(`findTooltip() throws an Error in when a non-tooltip is found`, async function(assert) {
+      assert.expect(1);
+
+      await render(hbs`<div class="test-tooltip"></div>`);
+
+      let funcToError = () => {
+        helperInstance(assert, {
+          selector: '.test-tooltip',
+        });
+      };
+
+      assert.throws(funcToError, Error,
+        'helperInstance should throw an Error');
+
+    });
+  });
+
+  test('findTooltip() can find a tooltip based on the class passed to the component', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{ember-tooltip text='hello' class='js-tooltip-component-element' isShown=true}}`);
+
+    assertTooltipRendered(assert, { selector: '.js-tooltip-component-element' });
+  });
+
+  test('findTooltip() can find a tooltip based on tooltipClassName passed to the component', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs`{{ember-tooltip text='hello' tooltipClassName='ember-tooltip js-class-on-the-popper-element' isShown=true}}`);
+
+    assertTooltipRendered(assert, { selector: '.js-class-on-the-popper-element' });
+  });
+
+  test('findTooltip() will not throw en error with assertTooltipNotRendered', async function(assert) {
+    assert.expect(1);
+
+    await render(hbs``);
+
+    assertTooltipNotRendered(assert);
+
+  });
+});

--- a/tests/integration/components/hide-on-test.js
+++ b/tests/integration/components/hide-on-test.js
@@ -6,7 +6,7 @@ import {
   assertTooltipNotRendered,
   assertTooltipNotVisible,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | hideOn', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/input-test.js
+++ b/tests/integration/components/input-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent, find } from '@ember/test-helpers';
 import {
   assertTooltipNotVisible,
   assertTooltipNotRendered,
 	assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Option | click', function(hooks) {
@@ -20,7 +20,7 @@ module('Integration | Option | click', function(hooks) {
       {{ember-tooltip event="click" targetId="some-input" enableLazyRendering=true}}
     `);
 
-    const [ tooltipTarget ] = this.$('#some-input');
+    const tooltipTarget = find('#some-input');
 
     assertTooltipNotRendered(assert);
 

--- a/tests/integration/components/keydown-test.js
+++ b/tests/integration/components/keydown-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipVisible,
   assertTooltipNotVisible
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Component | keydown', function(hooks) {
   setupRenderingTest(hooks);
@@ -25,7 +25,7 @@ module('Integration | Component | keydown', function(hooks) {
 
     assertTooltipVisible(assert, { selector: '.test-tooltip1' });
     assertTooltipVisible(assert, { selector: '.test-tooltip2' });
-    
+
     const { element } = this;
     await triggerKeyEvent(element, 'keydown', 27);
 

--- a/tests/integration/components/popover/api-test.js
+++ b/tests/integration/components/popover/api-test.js
@@ -11,7 +11,7 @@ import {
   assertTooltipNotRendered,
   assertTooltipNotVisible,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | API', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/popover/click-test.js
+++ b/tests/integration/components/popover/click-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render, triggerEvent } from '@ember/test-helpers';
+import { click, render, triggerEvent, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipVisible,
   assertTooltipNotRendered,
   assertTooltipNotVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | click', function(hooks) {
   setupRenderingTest(hooks);
@@ -135,7 +135,7 @@ module('Integration | Option | click', function(hooks) {
       {{ember-popover event='click' targetId='some-input' popoverHideDelay=0}}
     `);
 
-    const [ popoverTarget ] = this.$('#some-input');
+    const popoverTarget = find('#some-input');
 
     assertTooltipNotRendered(assert);
 

--- a/tests/integration/components/popover/event-bubbling-test.js
+++ b/tests/integration/components/popover/event-bubbling-test.js
@@ -1,11 +1,10 @@
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent, find, click } from '@ember/test-helpers';
 import {
   assertTooltipVisible,
-  assertTooltipNotRendered,
-} from 'ember-tooltips/test-support';
+  assertTooltipNotRendered
+} from 'ember-tooltips/test-support/dom/assertions';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Option | Event bubbling', function(hooks) {
@@ -58,16 +57,16 @@ module('Integration | Option | Event bubbling', function(hooks) {
 
     await triggerEvent(this.element, 'mouseenter');
 
-    const $button = $('.test-button-with-action');
+    const button = find('.test-button-with-action');
 
     assertTooltipVisible(assert);
 
-    assert.equal($button.length, 1, 'the button can be found');
+    assert.ok(button, 'the button can be found');
 
     /* Click the button to fire testAction. This will
     call the final assertion and the test will end. */
 
-    $button.trigger('click');
+    await click(button);
 
   });
 });

--- a/tests/integration/components/popover/focus-test.js
+++ b/tests/integration/components/popover/focus-test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotVisible,
   assertTooltipNotRendered,
-  assertTooltipVisible,
-  findTooltip,
-} from 'ember-tooltips/test-support';
+  assertTooltipVisible
+} from 'ember-tooltips/test-support/dom/assertions';
+import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 // const MS_FOR_BLUR = 100;
 
@@ -23,7 +23,7 @@ module('Integration | Option | focus', function(hooks) {
 
     await triggerEvent(this.element, 'focus');
 
-    const [ popover ] = findTooltip();
+    const popover = findTooltip();
 
     assertTooltipVisible(assert);
 
@@ -48,7 +48,7 @@ module('Integration | Option | focus', function(hooks) {
 
     await triggerEvent(this.element, 'focus');
 
-    const [ popover ] = findTooltip();
+    const popover = findTooltip();
 
     await triggerEvent('.target-interior', 'focus');
 
@@ -76,7 +76,7 @@ module('Integration | Option | focus', function(hooks) {
 
     await triggerEvent(this.element, 'focus');
 
-    const [ popover ] = findTooltip();
+    const popover = findTooltip();
 
     assertTooltipVisible(assert);
 
@@ -101,7 +101,7 @@ module('Integration | Option | focus', function(hooks) {
       {{ember-popover event='focus' targetId='some-input' popoverHideDelay=0}}
     `);
 
-    const [ popoverTarget ] = this.$('#some-input');
+    const popoverTarget = find('#some-input');
 
     assertTooltipNotRendered(assert);
 

--- a/tests/integration/components/popover/hover-test.js
+++ b/tests/integration/components/popover/hover-test.js
@@ -7,7 +7,7 @@ import {
   assertTooltipNotRendered,
   assertTooltipNotVisible,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | hover', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/popover/none-test.js
+++ b/tests/integration/components/popover/none-test.js
@@ -3,8 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
-  assertTooltipNotRendered,
-} from 'ember-tooltips/test-support';
+  assertTooltipNotRendered
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | event', function(hooks) {
   setupRenderingTest(hooks);
@@ -15,7 +15,7 @@ module('Integration | Option | event', function(hooks) {
 
     await render(hbs`{{ember-popover event='none'}}`);
 
-    const [ popoverTarget ] = this.$();
+    const popoverTarget = this.element;
 
     assertTooltipNotRendered(assert);
 

--- a/tests/integration/components/show-hide-show-test.js
+++ b/tests/integration/components/show-hide-show-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotRendered,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Component | show-hide-show', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/show-on-test.js
+++ b/tests/integration/components/show-on-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipNotRendered,
   assertTooltipVisible,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | showOn', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/side-test.js
+++ b/tests/integration/components/side-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipSide,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | side', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/spacing-test.js
+++ b/tests/integration/components/spacing-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipSpacing,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | spacing', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/target-test.js
+++ b/tests/integration/components/target-test.js
@@ -1,12 +1,11 @@
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   findTooltip,
   findTooltipTarget,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom';
 
 module('Integration | Component | target', function(hooks) {
   setupRenderingTest(hooks);
@@ -19,24 +18,24 @@ module('Integration | Component | target', function(hooks) {
       {{ember-tooltip targetId='some-target'}}
     `);
 
-    const expectedTarget = this.$().find('#some-target');
-    const [ target ] = findTooltipTarget();
+    const expectedTarget = find('#some-target');
+    const target = findTooltipTarget();
 
-    assert.ok(expectedTarget.hasClass('ember-tooltip-target'),
+    assert.ok(expectedTarget.classList.contains('ember-tooltip-target'),
         '#some-target should be the tooltip target');
 
-    assert.equal(expectedTarget[0], target,
+    assert.equal(expectedTarget, target,
       'The element with ID equal to targetID should be the tooltip target');
 
     await triggerEvent(target, 'mouseenter');
 
     const tooltip = findTooltip();
-    const targetDescribedby = $(target).attr('aria-describedby');
+    const targetDescribedby = target.getAttribute('aria-describedby');
 
     assert.ok(!!targetDescribedby,
       'The target should have an aria-describedby attribute after the tooltip renders');
 
-    assert.equal(targetDescribedby, tooltip.attr('id'),
+    assert.equal(targetDescribedby, tooltip.getAttribute('id'),
       `The tooltip ID should match the target's aria-describedby attribute`);
 
   });

--- a/tests/integration/components/text-test.js
+++ b/tests/integration/components/text-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipRendered,
   assertTooltipContent,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Component | inline', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/title-test.js
+++ b/tests/integration/components/title-test.js
@@ -6,8 +6,8 @@ import {
   assertTooltipContent,
   assertTooltipNotVisible,
   assertTooltipVisible,
-  findTooltipTarget,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
+import { findTooltipTarget} from 'ember-tooltips/test-support/dom';
 
 module('Integration | Component | title', function(hooks) {
   setupRenderingTest(hooks);
@@ -21,7 +21,7 @@ module('Integration | Component | title', function(hooks) {
       </div>
     `);
 
-    const [ target ] = findTooltipTarget();
+    const target = findTooltipTarget();
 
     await triggerEvent(target, 'mouseenter');
 

--- a/tests/integration/components/update-for-test.js
+++ b/tests/integration/components/update-for-test.js
@@ -4,7 +4,7 @@ import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   assertTooltipContent,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Option | updateFor', function(hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/config/body-element-id-test.js
+++ b/tests/integration/config/body-element-id-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   findTooltip,
-} from 'ember-tooltips/test-support';
+} from 'ember-tooltips/test-support/dom';
 
 module('Integration | Config | body-element-id', function(hooks) {
   setupRenderingTest(hooks);
@@ -15,11 +15,11 @@ module('Integration | Config | body-element-id', function(hooks) {
 
     await render(hbs`{{ember-tooltip isShown=true}}`);
 
-    const $tooltip = findTooltip();
-    const $tooltipParent = $tooltip.parent();
-    const tooltipParentId = $tooltipParent.attr('id');
+    const tooltip = findTooltip();
+    const tooltipParent = tooltip.parentElement;
+    const tooltipParentId = tooltipParent.getAttribute('id');
 
-    assert.notEqual($tooltipParent.attr('tagname'), 'body',
+    assert.notEqual(tooltipParent.tagName, 'BODY',
       'The tooltip should not be a child of the document body');
 
     assert.equal(tooltipParentId, 'ember-testing',


### PR DESCRIPTION
This PR changes the test helpers to work without jQuery.

In order to remain backwards compatible, all DOM-based test helpers were "copied" into a `dom` folder. You can import these variants like this:

```js
import { 
  findTooltip, 
  findTooltipTarget, 
  getPositionDifferences 
} from 'ember-tooltips/test-support/dom';
```

Also, the provided asserts use the new jQuery-free helpers under the hood - so if you use them, you don't need to change anything at all.

The new test helpers work mostly the same. However, `findTooltip` has a slightly different API, as it now needs to differentiate between one/multiple tooltips (vs. jQuery collections, which behave the same in both cases). 

`findTooltip` works in these ways:

```js
let tooltip = findTooltip(); // get first tooltip - returns a single DOM element
let allTooltips = findTooltip(null, { searchMultiple: true }); // get all tooltips - returns an array of DOM elements
let specificTooltip = findTooltip('.my-class');
let specificTooltips = findTooltip('.my-class', { searchMultiple: true });
let tooltipForTarget = findTooltip(myTargetDomElement);
```

Finally, it also now allows a `targetSelector` option, to get a specific tooltip element for a given target selector - which is used by `getTooltipAndTargetPosition()` under the hood.

Additionally, this PR also refactors all tests to stop using jQuery, and disables jQuery for the dummy app.

I guess in the future, the jQuery based test helpers should be deprecated, and finally removed.

This fixes #307 .