### PR TITLE
Fix issues with inconsistent application of targetSelector option in test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Documentation for usage is below:
 - [Actions](#actions)
 - [Testing](#testing)
   - [Test helpers](#test-helpers)
+    - [Importing test helpers](#importing-test-helpers)
 - [Accessibility](#accessibility)
 - [Development](#development)
 
@@ -577,15 +578,39 @@ Publically available test helpers are:
 - [assertTooltipSide()](#asserttooltipside)
 - [assertTooltipSpacing()](#asserttooltipspacing)
 
-All assert helpers require `assert` to be passed as the first param and some accept a second, optional param for additional test options. For detailed usage instructions and examples, see the documentation for each test helper below.
+All assert helpers require `assert` to be passed as the first param and some accept a second, optional param for additional test options.
+All assert helpers work with both QUnit's `assert` and chai's `assert`.
 
-All test helpers can be imported from the following path:
+For detailed usage instructions and examples, see the documentation for each test helper below.
+
+#### Importing test helpers
+
+There are currently two supported flavors of test helpers: one implementation
+uses jQuery and one uses the browser's DOM APIs (`querySelector`, etc.). The two
+share the same APIs, with exception for the types of selectors they support.
+
+#### DOM API test helpers (3.3.0+)
+
+The DOM API assertion test helpers can be found under the following module:
+
+```js
+'ember-tooltips/test-support/dom/assertions';
+```
+
+#### jQuery test helpers (deprecated in 3.3.0+)
+
+The jQuery assertion test helpers support jQuery-specific pseudoselectors like
+`:contains`. However, as jQuery is now optional in Ember 3.4+ and the use-cases
+for jQuery-specific selectors and the use of the library are small, these
+helpers will likely be removed in the next major release of `ember-tooltips`.
+
+The jQuery assertion test helpers live under the following module.:
 
 ```js
 'ember-tooltips/test-support';
 ```
 
-For example:
+#### Example
 
 ```js
 /* appname/tests/integration/components/some-component.js */
@@ -596,6 +621,8 @@ import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 import { assertTooltipRendered } from 'ember-tooltips/test-support';
+// Or, on ember-tooltips 3.3.0+ and not using jQuery:
+// import { assertTooltipRendered } from 'ember-tooltips/test-support/dom/assertions';
 
 module('Integration | Component | Some component', function(hooks) {
   setupRenderingTest(hooks);

--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ The [options hash](#test-helper-options) accepts:
 
 - [`contentString`](#test-helper-option-contentstring)
 - [`selector`](#test-helper-option-selector)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipRendered()
 
@@ -683,6 +684,7 @@ Given this addon's lazy rendering capabilities (explained in [`targetId`](#targe
 The [options hash](#test-helper-options) accepts:
 
 - [`selector`](#test-helper-option-selector)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipNotRendered()
 
@@ -707,6 +709,7 @@ This helper does not assert that the tooltip or popover is not visible to the us
 The [options hash](#test-helper-options) accepts:
 
 - [`selector`](#test-helper-option-selector)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipVisible()
 
@@ -752,6 +755,7 @@ test('Example test', async function(assert) {
 The [options hash](#test-helper-options) accepts:
 
 - [`selector`](#test-helper-option-selector)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipNotVisible()
 
@@ -791,6 +795,7 @@ test('Example test', async function(assert) {
 The [options hash](#test-helper-options) accepts:
 
 - [`selector`](#test-helper-option-selector)
+- [`targetSelector`](#test-helper-option-targetselector)
 
 #### assertTooltipSide()
 

--- a/addon-test-support/assertions/assert-tooltip-content.js
+++ b/addon-test-support/assertions/assert-tooltip-content.js
@@ -9,7 +9,7 @@ export default function assertTooltipContent(assert, options = {}) {
     emberAssert('You must specify a contentString property in the options parameter');
   }
 
-  const $tooltip = findTooltip(selector);
+  const $tooltip = findTooltip(selector, options);
   const tooltipContent = $tooltip.text().trim();
 
   assert.equal(tooltipContent, contentString,

--- a/addon-test-support/assertions/assert-tooltip-not-rendered.js
+++ b/addon-test-support/assertions/assert-tooltip-not-rendered.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support';
 
 export default function assertTooltipNotRendered(assert, options = {}) {
   const { selector } = options;
-  const $tooltip = findTooltip(selector);
+  const $tooltip = findTooltip(selector, options);
 
   assert.equal($tooltip.length, 0, 'assertTooltipNotRendered(): the ember-tooltip should not be rendered');
 }

--- a/addon-test-support/assertions/assert-tooltip-not-visible.js
+++ b/addon-test-support/assertions/assert-tooltip-not-visible.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support';
 
 export default function assertTooltipNotVisible(assert, options = {}) {
   const { selector } = options;
-  const $tooltip = findTooltip(selector);
+  const $tooltip = findTooltip(selector, options);
   const ariaHidden = $tooltip.attr('aria-hidden');
 
   assert.ok(ariaHidden === 'true',

--- a/addon-test-support/assertions/assert-tooltip-rendered.js
+++ b/addon-test-support/assertions/assert-tooltip-rendered.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support';
 
 export default function assertTooltipRendered(assert, options = {}) {
   const { selector } = options;
-  const $tooltip = findTooltip(selector);
+  const $tooltip = findTooltip(selector, options);
 
   assert.equal($tooltip.length, 1, 'assertTooltipRendered(): the ember-tooltip should be rendered');
 }

--- a/addon-test-support/assertions/assert-tooltip-visible.js
+++ b/addon-test-support/assertions/assert-tooltip-visible.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support';
 
 export default function assertTooltipVisible(assert, options = {}) {
   const { selector } = options;
-  const $tooltip = findTooltip(selector);
+  const $tooltip = findTooltip(selector, options);
   const ariaHidden = $tooltip.attr('aria-hidden');
 
   assert.ok(ariaHidden === 'false',

--- a/addon-test-support/dom/assertions/assert-tooltip-content.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-content.js
@@ -9,7 +9,7 @@ export default function assertTooltipContent(assert, options = {}) {
     emberAssert('You must specify a contentString property in the options parameter');
   }
 
-  const tooltip = findTooltip(selector);
+  const tooltip = findTooltip(selector, options);
   const tooltipContent = tooltip.innerText.trim();
 
   assert.equal(tooltipContent, contentString,

--- a/addon-test-support/dom/assertions/assert-tooltip-not-rendered.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-not-rendered.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 export default function assertTooltipNotRendered(assert, options = {}) {
   const { selector } = options;
-  const tooltip = findTooltip(selector);
+  const tooltip = findTooltip(selector, options);
 
   assert.notOk(tooltip, 'assertTooltipNotRendered(): the ember-tooltip should not be rendered');
 }

--- a/addon-test-support/dom/assertions/assert-tooltip-not-visible.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-not-visible.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 export default function assertTooltipNotVisible(assert, options = {}) {
   const { selector } = options;
-  const tooltip = findTooltip(selector);
+  const tooltip = findTooltip(selector, options);
   const ariaHidden = tooltip.getAttribute('aria-hidden');
 
   assert.ok(ariaHidden === 'true',

--- a/addon-test-support/dom/assertions/assert-tooltip-rendered.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-rendered.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 export default function assertTooltipRendered(assert, options = {}) {
   const { selector } = options;
-  const tooltip = findTooltip(selector);
+  const tooltip = findTooltip(selector, options);
 
   assert.ok(tooltip, 'assertTooltipRendered(): the ember-tooltip should be rendered');
 }

--- a/addon-test-support/dom/assertions/assert-tooltip-visible.js
+++ b/addon-test-support/dom/assertions/assert-tooltip-visible.js
@@ -2,7 +2,7 @@ import { findTooltip } from 'ember-tooltips/test-support/dom';
 
 export default function assertTooltipVisible(assert, options = {}) {
   const { selector } = options;
-  const tooltip = findTooltip(selector);
+  const tooltip = findTooltip(selector, options);
   const ariaHidden = tooltip.getAttribute('aria-hidden');
 
   assert.ok(ariaHidden === 'false',

--- a/addon-test-support/utils/find-tooltip.js
+++ b/addon-test-support/utils/find-tooltip.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 
-export default function findTooltip(selector) {
+export default function findTooltip(selector, { targetSelector } = {}) {
 
   if (!selector) { // In case of passing null, undefined, etc
     selector = '.ember-tooltip, .ember-popover';
@@ -9,24 +9,38 @@ export default function findTooltip(selector) {
   /* We .find() tooltips from $body instead of using ember-test-helper's
   find() method because tooltips and popovers are often rendered as
   children of <body> instead of children of the $targetElement */
+  let $tooltips = $(document.body).find(selector);
+  const tooltipElements = $tooltips.toArray().
+    map((el) => getActualTooltip(el, targetSelector)).
+    filter((el) => el);
+  $tooltips = $(tooltipElements);
 
-  const $body = $(document.body);
-  let $tooltip = $body.find(selector);
+  if ($tooltips.length && !$tooltips.hasClass('ember-tooltip') && !$tooltips.hasClass('ember-popover')) {
+    throw Error(`getTooltipFromBody(): returned an element that is not a tooltip`);
+  } else if ($tooltips.length > 1) {
+    console.warn(`getTooltipFromBody(): Multiple tooltips were found. Consider passing { selector: '.specific-tooltip-class' }`);
+  }
 
-  if ($tooltip.length && $tooltip.hasClass('ember-tooltip-base')) {
+  return $tooltips;
+}
+
+function getActualTooltip(tooltip, targetSelector) {
+  let $tooltip = $(tooltip);
+
+  if ($tooltip.hasClass('ember-tooltip-base')) {
     /* If what we find is the actually the tooltip component's element, we can
      * look up the intended tooltip by the element referenced by its target
      * element's aria-describedby attribute.
      */
-    const $target = $tooltip.parents('.ember-tooltip-target, .ember-popover-target');
-    $tooltip = $body.find(`#${$target.attr('aria-describedby')}`);
+    const $target = $tooltip.closest('.ember-tooltip-target, .ember-popover-target');
+
+    // If a targetSelector is specified, filter by it
+    if (!$target.length || (targetSelector && !$target.is(targetSelector))) {
+      return null;
+    }
+
+    $tooltip = $(document.body).find(`#${$target.attr('aria-describedby')}`);
   }
 
-  if ($tooltip.length && !$tooltip.hasClass('ember-tooltip') && !$tooltip.hasClass('ember-popover')) {
-    throw Error(`getTooltipFromBody(): returned an element that is not a tooltip`);
-  } else if ($tooltip.length > 1) {
-    console.warn(`getTooltipFromBody(): Multiple tooltips were found. Consider passing { selector: '.specific-tooltip-class' }`);
-  }
-
-  return $tooltip;
+  return $tooltip[0];
 }

--- a/addon-test-support/utils/get-position-differences.js
+++ b/addon-test-support/utils/get-position-differences.js
@@ -49,7 +49,7 @@ export default function getPositionDifferences(options = {}) {
 export function getTooltipAndTargetPosition(options = {}) {
   const { selector, targetSelector } = options;
   const [ target ] = findTooltipTarget(targetSelector);
-  const [ tooltip ] = findTooltip(selector);
+  const [ tooltip ] = findTooltip(selector, { targetSelector });
 
   const targetPosition = target.getBoundingClientRect();
   const tooltipPosition = tooltip.getBoundingClientRect();

--- a/tests/integration/components/helpers/dom/find-tooltip-test.js
+++ b/tests/integration/components/helpers/dom/find-tooltip-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
+  assertTooltipContent,
   assertTooltipNotVisible,
   assertTooltipVisible,
   assertTooltipNotRendered,
@@ -53,5 +54,33 @@ module('Integration | Helpers | dom | findTooltip', function(hooks) {
 
     assertTooltipNotRendered(assert);
 
+  });
+
+  test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      <div class="target-a">
+        {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
+      </div>
+      <div class="target-b">
+        {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+      </div>
+      <div class="target-c">
+        {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
+      </div>
+    `);
+
+    assertTooltipContent(assert, {
+      selector: '.common-tooltip',
+      targetSelector: '.target-b',
+      contentString: 'Bye'
+    });
+
+    assertTooltipContent(assert, {
+      selector: '.common-tooltip',
+      targetSelector: '.target-c',
+      contentString: 'Huh'
+    });
   });
 });

--- a/tests/integration/components/helpers/dom/find-tooltip-test.js
+++ b/tests/integration/components/helpers/dom/find-tooltip-test.js
@@ -56,31 +56,47 @@ module('Integration | Helpers | dom | findTooltip', function(hooks) {
 
   });
 
-  test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
-    assert.expect(2);
+  [
+    assertTooltipContent,
+    assertTooltipVisible,
+    assertTooltipRendered
+  ].forEach(function (assertFn) {
+    test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
+      assert.expect(3);
 
-    await render(hbs`
-      <div class="target-a">
-        {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
-      </div>
-      <div class="target-b">
-        {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
-      </div>
-      <div class="target-c">
-        {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
-      </div>
-    `);
+      await render(hbs`
+        <div class="target-a">
+          {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none' spacing=30}}
+        </div>
+        <div class="target-b">
+          {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+        </div>
+        <div class="target-c">
+          {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
+        </div>
+      `);
 
-    assertTooltipContent(assert, {
-      selector: '.common-tooltip',
-      targetSelector: '.target-b',
-      contentString: 'Bye'
-    });
+      assertFn(assert, {
+        side: 'top',
+        selector: '.common-tooltip',
+        spacing: 30,
+        targetSelector: '.target-a',
+        contentString: 'Hi'
+      });
 
-    assertTooltipContent(assert, {
-      selector: '.common-tooltip',
-      targetSelector: '.target-c',
-      contentString: 'Huh'
+      assertFn(assert, {
+        side: 'left',
+        selector: '.common-tooltip',
+        targetSelector: '.target-b',
+        contentString: 'Bye'
+      });
+
+      assertFn(assert, {
+        side: 'right',
+        selector: '.common-tooltip',
+        targetSelector: '.target-c',
+        contentString: 'Huh'
+      });
     });
   });
 });

--- a/tests/integration/components/helpers/find-tooltip-test.js
+++ b/tests/integration/components/helpers/find-tooltip-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
+  assertTooltipContent,
   assertTooltipNotVisible,
   assertTooltipVisible,
   assertTooltipNotRendered,
@@ -62,5 +63,33 @@ module('Integration | Helpers | findTooltip', function(hooks) {
 
     assertTooltipNotRendered(assert);
 
+  });
+
+  test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      <div class="target-a">
+        {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
+      </div>
+      <div class="target-b">
+        {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+      </div>
+      <div class="target-c">
+        {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
+      </div>
+    `);
+
+    assertTooltipContent(assert, {
+      selector: '.common-tooltip',
+      targetSelector: '.target-b',
+      contentString: 'Bye'
+    });
+
+    assertTooltipContent(assert, {
+      selector: '.common-tooltip',
+      targetSelector: '.target-c',
+      contentString: 'Huh'
+    });
   });
 });

--- a/tests/integration/components/helpers/find-tooltip-test.js
+++ b/tests/integration/components/helpers/find-tooltip-test.js
@@ -65,31 +65,47 @@ module('Integration | Helpers | findTooltip', function(hooks) {
 
   });
 
-  test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
-    assert.expect(2);
+  [
+    assertTooltipContent,
+    assertTooltipVisible,
+    assertTooltipRendered
+  ].forEach(function (assertFn) {
+    test('findTooltip() can find the correct tooltip among many when given a targetSelector', async function(assert) {
+      assert.expect(3);
 
-    await render(hbs`
-      <div class="target-a">
-        {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none'}}
-      </div>
-      <div class="target-b">
-        {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
-      </div>
-      <div class="target-c">
-        {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
-      </div>
-    `);
+      await render(hbs`
+        <div class="target-a">
+          {{ember-tooltip class="common-tooltip" side='top' isShown=true text='Hi' effect='none' spacing=30}}
+        </div>
+        <div class="target-b">
+          {{ember-tooltip class="common-tooltip" side='left' isShown=true text='Bye' effect='none'}}
+        </div>
+        <div class="target-c">
+          {{ember-tooltip class="common-tooltip" side='right' isShown=true text='Huh' effect='none'}}
+        </div>
+      `);
 
-    assertTooltipContent(assert, {
-      selector: '.common-tooltip',
-      targetSelector: '.target-b',
-      contentString: 'Bye'
-    });
+      assertFn(assert, {
+        side: 'top',
+        selector: '.common-tooltip',
+        spacing: 30,
+        targetSelector: '.target-a',
+        contentString: 'Hi'
+      });
 
-    assertTooltipContent(assert, {
-      selector: '.common-tooltip',
-      targetSelector: '.target-c',
-      contentString: 'Huh'
+      assertFn(assert, {
+        side: 'left',
+        selector: '.common-tooltip',
+        targetSelector: '.target-b',
+        contentString: 'Bye'
+      });
+
+      assertFn(assert, {
+        side: 'right',
+        selector: '.common-tooltip',
+        targetSelector: '.target-c',
+        contentString: 'Huh'
+      });
     });
   });
 });

--- a/tests/integration/components/helpers/find-tooltip-test.js
+++ b/tests/integration/components/helpers/find-tooltip-test.js
@@ -86,7 +86,6 @@ module('Integration | Helpers | findTooltip', function(hooks) {
       `);
 
       assertFn(assert, {
-        side: 'top',
         selector: '.common-tooltip',
         spacing: 30,
         targetSelector: '.target-a',
@@ -94,14 +93,12 @@ module('Integration | Helpers | findTooltip', function(hooks) {
       });
 
       assertFn(assert, {
-        side: 'left',
         selector: '.common-tooltip',
         targetSelector: '.target-b',
         contentString: 'Bye'
       });
 
       assertFn(assert, {
-        side: 'right',
         selector: '.common-tooltip',
         targetSelector: '.target-c',
         contentString: 'Huh'


### PR DESCRIPTION
While writing up docs for the new jQuery-free test helpers, I was upgrading our main app at work, and found a test that started failing with the new helpers, related to the checking for the correct target element when using `targetSelector`. I found that this behavior was actually correct, based on what `targetSelector` is supposed to do, and found that `targetSelector` was being applied inconsistently, resulting in the wrong element being returned in many cases. The jQuery `findTooltip` was not checking the classes of the tooltip/popover target retrieved (in the cases where a selector to the tooltip wrapper is passed as `selector`) with the `targetSelector` specified to the original assertion helper.

This PR updates the jQuery implementation of `findTooltip` to match the semantics of the regular DOM implementation and contains the new docs section on using the new DOM implementation.