### PR TITLE
Fix sourcemaps

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,6 +10,11 @@ module.exports = function(defaults) {
 
     minifyCSS: {
       enabled: false // CSS minification w/ @import rules seems to be broken in Ember-CLI 3.3
+    },
+
+    sourcemaps: {
+      enabled: true,
+      extensions: ['js']
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,38 @@
 "use strict";
 
+const funnel = require('broccoli-funnel');
+const stringReplace = require('broccoli-string-replace');
+const MergedTrees = require('broccoli-merge-trees');
+const UnwatchedDir = require('broccoli-source').UnwatchedDir;
+const path = require('path');
+
 module.exports = {
   name: require("./package").name,
+
+  findModulePath(basedir, moduleName) {
+    try {
+      const resolve = require('resolve'); // eslint-disable-line node/no-extraneous-require
+      return path.dirname(resolve.sync(moduleName, { basedir: basedir }));
+    } catch (_) {
+      try {
+        return path.dirname(require.resolve(moduleName));
+      } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+          this.ui.writeLine(
+            `ember-tooltips: ${moduleName} not installed, be sure you have ${moduleName} installed via npm/yarn.`
+          );
+          return;
+        }
+
+        throw e;
+      }
+    }
+  },
 
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    app.import("node_modules/popper.js/dist/umd/popper.js", {
+    app.import("vendor/popper.js", {
       using: [
         {
           transformation: "amd",
@@ -14,8 +40,7 @@ module.exports = {
         }
       ]
     });
-    app.import("node_modules/popper.js/dist/umd/popper.js.map", { destDir: 'assets' });
-    app.import("node_modules/tooltip.js/dist/umd/tooltip.js", {
+    app.import("vendor/tooltip.js", {
       using: [
         {
           transformation: "amd",
@@ -23,7 +48,23 @@ module.exports = {
         }
       ]
     });
-    app.import("node_modules/tooltip.js/dist/umd/tooltip.js.map", { destDir: 'assets' });
+  },
+
+  removeSourcemapAnnotation(node) {
+    return stringReplace(node, {
+      files: ['popper.js', 'tooltip.js'],
+      annotation: 'Remove sourcemap annotation (popper.js & tooltip.js)',
+      patterns: [
+        {
+          match: /\/\/# sourceMappingURL=popper.js.map/g,
+          replacement: ''
+        },
+        {
+          match: /\/\/# sourceMappingURL=tooltip.js.map/g,
+          replacement: ''
+        }
+      ]
+    });
   },
 
   treeForAddonTestSupport(tree) {
@@ -38,9 +79,24 @@ module.exports = {
       `export * from '${this.moduleName()}/test-support/${testType}';`
     );
 
-    const MergedTrees = require('broccoli-merge-trees');
     const mergedTree = new MergedTrees([tree, reexportTree]);
 
     return this._super(mergedTree);
+  },
+
+  treeForVendor(tree) {
+    let popperPath = this.findModulePath(this.project.root, 'popper.js');
+    let popperTree = funnel(new UnwatchedDir(popperPath), {
+      include: ['popper.js']
+    });
+
+    let tooltipPath = this.findModulePath(this.project.root, 'tooltip.js');
+    let tooltipTree = funnel(new UnwatchedDir(tooltipPath), {
+      include: ['tooltip.js']
+    });
+
+    const mergedTree = new MergedTrees([tree, popperTree, tooltipTree]);
+
+    return this.removeSourcemapAnnotation(mergedTree);
   }
 };

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
         }
       ]
     });
+    app.import("node_modules/popper.js/dist/umd/popper.js.map", { destDir: 'assets' });
     app.import("node_modules/tooltip.js/dist/umd/tooltip.js", {
       using: [
         {
@@ -22,6 +23,7 @@ module.exports = {
         }
       ]
     });
+    app.import("node_modules/tooltip.js/dist/umd/tooltip.js.map", { destDir: 'assets' });
   },
 
   treeForAddonTestSupport(tree) {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,18 @@
   },
   "dependencies": {
     "@ember/optional-features": "^0.6.3",
+    "broccoli-funnel": "^2.0.2",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-source": "^2.0.0",
+    "broccoli-string-replace": "^0.1.2",
     "ember-cli-babel": "^6.16.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-get-config": "^0.2.4",
     "ember-wormhole": "^0.5.5",
     "popper.js": "^1.12.5",
-    "tooltip.js": "^1.1.5"
+    "tooltip.js": "^1.1.5",
+    "resolve": "^1.10.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,6 +1749,25 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
+broccoli-funnel@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz#0edf629569bc10bd02cc525f74b9a38e71366a75"
+  integrity sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
 broccoli-kitchen-sink-helpers@^0.2.0, broccoli-kitchen-sink-helpers@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
@@ -1830,9 +1849,10 @@ broccoli-node-info@1.1.0, broccoli-node-info@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz#3aa2e31e07e5bdb516dd25214f7c45ba1c459412"
 
-broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
+broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz#80762d19000880a77da33c34373299c0f6a3e615"
+  integrity sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==
   dependencies:
     async-disk-cache "^1.2.1"
     async-promise-queue "^1.0.3"
@@ -1910,6 +1930,11 @@ broccoli-source@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-1.1.0.tgz#54f0e82c8b73f46580cbbc4f578f0b32fca8f809"
 
+broccoli-source@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-2.0.0.tgz#02d3f369fd0ef1b25c0b1646cc3c87d4c7f76cc0"
+  integrity sha512-2rRtM8WGvZFwLY+HdBflnri/r44ldx5Kc5QPlW5rRREzGt61iP22WnJzM4KY509KtDvQCeb+QDlRgxE+RkjE7A==
+
 broccoli-sri-hash@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/broccoli-sri-hash/-/broccoli-sri-hash-2.1.2.tgz#bc69905ed7a381ad325cc0d02ded071328ebf3f3"
@@ -1965,6 +1990,14 @@ broccoli-stew@^2.0.0:
     rsvp "^4.8.4"
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.3"
+
+broccoli-string-replace@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz#1ed92f85680af8d503023925e754e4e33676b91f"
+  integrity sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=
+  dependencies:
+    broccoli-persistent-filter "^1.1.5"
+    minimatch "^3.0.3"
 
 broccoli-templater@^2.0.1:
   version "2.0.2"
@@ -5589,7 +5622,7 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -6104,7 +6137,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -6607,6 +6640,13 @@ resolve@^1.1.3, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, 
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+  dependencies:
+    path-parse "^1.0.6"
 
 responselike@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
popper.js & tooltip.js ship with pre-compiled sourcemaps and we need to include those in order for sourcemap generation to work.

Fixes #354 