### PR TITLE
Query @ember/optional-features from host app

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,10 +69,12 @@ module.exports = {
 
   treeForAddonTestSupport(tree) {
     const writeFile = require('broccoli-file-creator');
-    const optionalFeatures = this.addons.find(a => a.name === '@ember/optional-features');
-    const testType = optionalFeatures.isFeatureEnabled('jquery-integration')
-      ? 'jquery'
-      : 'dom';
+    // this.project.findAddonByName is marked private, but everyone else is doing it
+    // so ¯\_(ツ)_/¯
+    const optionalFeatures = this.project.findAddonByName('@ember/optional-features');
+    const testType = optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')
+      ? 'dom'
+      : 'jquery';
 
     const reexportTree = writeFile(
       'index.js',

--- a/index.js
+++ b/index.js
@@ -69,8 +69,6 @@ module.exports = {
 
   treeForAddonTestSupport(tree) {
     const writeFile = require('broccoli-file-creator');
-    // this.project.findAddonByName is marked private, but everyone else is doing it
-    // so ¯\_(ツ)_/¯
     const optionalFeatures = this.project.findAddonByName('@ember/optional-features');
     const testType = optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')
       ? 'dom'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "@ember/optional-features": "^0.6.3",
     "broccoli-funnel": "^2.0.2",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^2.0.0",
@@ -44,6 +43,7 @@
     "resolve": "^1.10.1"
   },
   "devDependencies": {
+    "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,9 +525,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@ember/optional-features@^0.6.3":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.6.4.tgz#8199f853c1781234fcb1f05090cddd0b822bff69"
+"@ember/optional-features@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.7.0.tgz#f65a858007020ddfb8342f586112750c32abd2d9"
+  integrity sha512-qLXvL/Kq/COb43oQmCrKx7Fy8k1XJDI2RlgbCnZHH26AGVgJT/sZugx1A2AIxKdamtl/Mi+rQSjGIuscSjqjDw==
   dependencies:
     chalk "^2.3.0"
     co "^4.6.0"


### PR DESCRIPTION
We can grab `@ember/optional-features` from the host application, rather than depending on it directly.

Fixes #355 & concerns raised in #351 