### PR TITLE
Avoid build conflict with ember-popper via ember-bootstrap

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    app.import("vendor/popper.js", {
+    app.import("vendor/ember-tooltips--popper.js", {
       using: [
         {
           transformation: "amd",
@@ -40,7 +40,7 @@ module.exports = {
         }
       ]
     });
-    app.import("vendor/tooltip.js", {
+    app.import("vendor/ember-tooltips--tooltip.js", {
       using: [
         {
           transformation: "amd",
@@ -97,6 +97,14 @@ module.exports = {
 
     const mergedTree = new MergedTrees([tree, popperTree, tooltipTree]);
 
-    return this.removeSourcemapAnnotation(mergedTree);
+    return funnel(this.removeSourcemapAnnotation(mergedTree), {
+      getDestinationPath(relativePath) {
+        if (relativePath === 'popper.js' || relativePath === 'tooltip.js') {
+          return `ember-tooltips--${relativePath}`;
+        }
+
+        return relativePath;
+      }
+    });
   }
 };


### PR DESCRIPTION
Fixes #360. Folks may still get two copies of `popper.js` and `tooltip.js` in their builds, but we don't want ember-tooltips to be a blocker for folks using ember-bootstrap, and this restores the behavior pre-3.3.1.