### PR TITLE
make tooltip arrows work for popovers

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -45,7 +45,8 @@
   user-select: auto;
 }
 
-.ember-tooltip-arrow {
+.ember-tooltip-arrow,
+.ember-popover-arrow {
   width: 0;
   height: 0;
   border-style: solid;
@@ -68,8 +69,8 @@
   opacity: 1;
 }
 
-.ember-tooltip[x-placement^="top"] .ember-tooltip-arrow,
-.ember-popover[x-placement^="top"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="top"] .tooltip-arrow,
+.ember-popover[x-placement^="top"] .tooltip-arrow {
   border-bottom-width: 0;
   bottom: -5px;
   left: calc(50% - 5px);
@@ -77,16 +78,16 @@
   margin-bottom: 0;
 }
 
-.ember-tooltip[x-placement^="top"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="top"] .tooltip-arrow {
   border-top-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="top"] .ember-tooltip-arrow {
+.ember-popover[x-placement^="top"] .tooltip-arrow {
   border-top-color: #fff;
 }
 
-.ember-tooltip[x-placement^="right"] .ember-tooltip-arrow,
-.ember-popover[x-placement^="right"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="right"] .tooltip-arrow,
+.ember-popover[x-placement^="right"] .tooltip-arrow {
   border-left-width: 0;
   left: -5px;
   top: calc(50% - 5px);
@@ -94,16 +95,16 @@
   margin-left: 0;
 }
 
-.ember-tooltip[x-placement^="right"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="right"] .tooltip-arrow {
   border-right-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="right"] .ember-tooltip-arrow {
+.ember-popover[x-placement^="right"] .tooltip-arrow {
   border-right-color: #fff;
 }
 
-.ember-tooltip[x-placement^="bottom"] .ember-tooltip-arrow,
-.ember-popover[x-placement^="bottom"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="bottom"] .tooltip-arrow,
+.ember-popover[x-placement^="bottom"] .tooltip-arrow {
   border-top-width: 0;
   top: -5px;
   left: calc(50% - 5px);
@@ -111,16 +112,16 @@
   margin-top: 0;
 }
 
-.ember-tooltip[x-placement^="bottom"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="bottom"] .tooltip-arrow {
   border-bottom-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="bottom"] .ember-tooltip-arrow {
+.ember-popover[x-placement^="bottom"] .tooltip-arrow {
   border-bottom-color: #fff;
 }
 
-.ember-tooltip[x-placement^="left"] .ember-tooltip-arrow,
-.ember-popover[x-placement^="left"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="left"] .tooltip-arrow,
+.ember-popover[x-placement^="left"] .tooltip-arrow {
   border-right-width: 0;
   right: -5px;
   top: calc(50% - 5px);
@@ -128,10 +129,10 @@
   margin-right: 0;
 }
 
-.ember-tooltip[x-placement^="left"] .ember-tooltip-arrow {
+.ember-tooltip[x-placement^="left"] .tooltip-arrow {
   border-left-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="left"] .ember-tooltip-arrow {
+.ember-popover[x-placement^="left"] .tooltip-arrow {
   border-left-color: #fff;
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -69,8 +69,8 @@
   opacity: 1;
 }
 
-.ember-tooltip[x-placement^="top"] .tooltip-arrow,
-.ember-popover[x-placement^="top"] .tooltip-arrow {
+.ember-tooltip[x-placement^="top"] .ember-tooltip-arrow,
+.ember-popover[x-placement^="top"] .ember-popover-arrow {
   border-bottom-width: 0;
   bottom: -5px;
   left: calc(50% - 5px);
@@ -78,16 +78,16 @@
   margin-bottom: 0;
 }
 
-.ember-tooltip[x-placement^="top"] .tooltip-arrow {
+.ember-tooltip[x-placement^="top"] .ember-tooltip-arrow {
   border-top-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="top"] .tooltip-arrow {
+.ember-popover[x-placement^="top"] .ember-popover-arrow {
   border-top-color: #fff;
 }
 
-.ember-tooltip[x-placement^="right"] .tooltip-arrow,
-.ember-popover[x-placement^="right"] .tooltip-arrow {
+.ember-tooltip[x-placement^="right"] .ember-tooltip-arrow,
+.ember-popover[x-placement^="right"] .ember-popover-arrow {
   border-left-width: 0;
   left: -5px;
   top: calc(50% - 5px);
@@ -95,16 +95,16 @@
   margin-left: 0;
 }
 
-.ember-tooltip[x-placement^="right"] .tooltip-arrow {
+.ember-tooltip[x-placement^="right"] .ember-tooltip-arrow {
   border-right-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="right"] .tooltip-arrow {
+.ember-popover[x-placement^="right"] .ember-popover-arrow {
   border-right-color: #fff;
 }
 
-.ember-tooltip[x-placement^="bottom"] .tooltip-arrow,
-.ember-popover[x-placement^="bottom"] .tooltip-arrow {
+.ember-tooltip[x-placement^="bottom"] .ember-tooltip-arrow,
+.ember-popover[x-placement^="bottom"] .ember-popover-arrow {
   border-top-width: 0;
   top: -5px;
   left: calc(50% - 5px);
@@ -112,16 +112,16 @@
   margin-top: 0;
 }
 
-.ember-tooltip[x-placement^="bottom"] .tooltip-arrow {
+.ember-tooltip[x-placement^="bottom"] .ember-tooltip-arrow {
   border-bottom-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="bottom"] .tooltip-arrow {
+.ember-popover[x-placement^="bottom"] .ember-popover-arrow {
   border-bottom-color: #fff;
 }
 
-.ember-tooltip[x-placement^="left"] .tooltip-arrow,
-.ember-popover[x-placement^="left"] .tooltip-arrow {
+.ember-tooltip[x-placement^="left"] .ember-tooltip-arrow,
+.ember-popover[x-placement^="left"] .ember-popover-arrow {
   border-right-width: 0;
   right: -5px;
   top: calc(50% - 5px);
@@ -129,10 +129,10 @@
   margin-right: 0;
 }
 
-.ember-tooltip[x-placement^="left"] .tooltip-arrow {
+.ember-tooltip[x-placement^="left"] .ember-tooltip-arrow {
   border-left-color: #3a3c47;
 }
 
-.ember-popover[x-placement^="left"] .tooltip-arrow {
+.ember-popover[x-placement^="left"] .ember-popover-arrow {
   border-left-color: #fff;
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -83,7 +83,7 @@
 }
 
 .ember-popover[x-placement^="top"] .ember-popover-arrow {
-  border-top-color: #fff;
+  border-top-color: #ccc;
 }
 
 .ember-tooltip[x-placement^="right"] .ember-tooltip-arrow,
@@ -100,7 +100,7 @@
 }
 
 .ember-popover[x-placement^="right"] .ember-popover-arrow {
-  border-right-color: #fff;
+  border-right-color: #ccc;
 }
 
 .ember-tooltip[x-placement^="bottom"] .ember-tooltip-arrow,
@@ -117,7 +117,7 @@
 }
 
 .ember-popover[x-placement^="bottom"] .ember-popover-arrow {
-  border-bottom-color: #fff;
+  border-bottom-color: #ccc;
 }
 
 .ember-tooltip[x-placement^="left"] .ember-tooltip-arrow,
@@ -134,5 +134,5 @@
 }
 
 .ember-popover[x-placement^="left"] .ember-popover-arrow {
-  border-left-color: #fff;
+  border-left-color: #ccc;
 }


### PR DESCRIPTION
Currently, the arrow styles only work for tooltips. The arrow styles are only targeting `.ember-tooltip-arrow`. However, popovers do not have this class; they have `class="tooltip-arrow ember-popover-arrow"`. Since both tooltips and popovers have the same `.tooltip-arrow` class, it can be used instead — nested under the namespace of `.ember-tooltip` and `.ember-popover`. 