### PR TITLE
Replace ember-wormhole with ember-maybe-in-element

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -181,8 +181,22 @@ export default Component.extend({
 
   /* An ID used to identify this tooltip from other tooltips */
 
-  wormholeId: computed('elementId', function() {
-    return `${this.get('elementId')}-wormhole`;
+  _renderElementId: computed('elementId', function() {
+    const elementId = this.get('elementId');
+    if (elementId) {
+      return `${elementId}-et-target`;
+    } else {
+      return null;
+    }
+  }),
+
+  _renderElement: computed('_renderElementId', function() {
+    const renderElementId = this.get('_renderElementId');
+    if (renderElementId) {
+      return document.getElementById(renderElementId);
+    } else {
+      return null;
+    }
   }),
 
   _fastboot: computed(function() {
@@ -357,7 +371,7 @@ export default Component.extend({
                    style="margin:0;margin-${getOppositeSide(this.get('side'))}:${this.get('spacing')}px;"
                  >
                    <div class="${arrowClass} ${emberTooltipArrowClass}"></div>
-                   <div class="${innerClass} ${emberTooltipInnerClass}" id="${this.get('wormholeId')}"></div>
+                   <div class="${innerClass} ${emberTooltipInnerClass}" id="${this.get('_renderElementId')}"></div>
                  </div>`,
 
       popperOptions: {

--- a/addon/templates/components/ember-tooltip-base.hbs
+++ b/addon/templates/components/ember-tooltip-base.hbs
@@ -1,4 +1,4 @@
-{{#ember-wormhole to=wormholeId renderInPlace=_awaitingTooltipElementRendered}}
+{{#maybe-in-element _renderElement _awaitingTooltipElementRendered}}
   <div>
     {{#if _shouldRenderContent}}
       {{#if (hasBlock)}}
@@ -8,4 +8,4 @@
       {{/if}}
     {{/if}}
   </div>
-{{/ember-wormhole}}
+{{/maybe-in-element}}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-babel": "^7.11.1",
     "ember-cli-htmlbars": "^4.0.0",
     "ember-get-config": "^0.2.4",
-    "ember-wormhole": "^0.5.5",
+    "ember-maybe-in-element": "^0.4.0",
     "popper.js": "^1.12.5",
     "resolve": "^1.10.1",
     "tooltip.js": "^1.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,7 +3341,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.17.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
   dependencies:
@@ -3852,6 +3852,13 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-maybe-in-element@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.4.0.tgz#fe1994c60ee64527d2b2f3b4479ebf8806928bd8"
+  integrity sha512-ADQ9jewz46Y2MWiTAKrheIukHiU6p0QHn3xqz1BBDDOmubW1WdAjSrvtkEWsJQ08DyxIn3RdMuNDzAUo6HN6qw==
+  dependencies:
+    ember-cli-babel "^7.1.0"
+
 ember-qunit@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-4.5.1.tgz#dc4b0a794fbeb6702a02f28bf19091de0f90fd5a"
@@ -3996,13 +4003,6 @@ ember-try@^1.2.1:
     rimraf "^2.6.3"
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
-
-ember-wormhole@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/ember-wormhole/-/ember-wormhole-0.5.5.tgz#db417ff748cb21e574cd5f233889897bc27096cb"
-  dependencies:
-    ember-cli-babel "^6.10.0"
-    ember-cli-htmlbars "^2.0.1"
 
 emit-function@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
This is a lighter weight dependency and works using the `in-element` helper built into Glimmer itself.

Supersedes #319 