### PR TITLE
Remove for..of loop for IE11 / no Symbol support

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -620,7 +620,7 @@ function mergeModifiers(defaults, overrides = {}) {
   }, []);
   const modifiers = assign({}, defaults);
 
-  for (const key of keys) {
+  keys.forEach((key) => {
     if (defaultKeys.includes(key) && overriddenKeys.includes(key)) {
       modifiers[key] = assign(
         {},
@@ -630,7 +630,7 @@ function mergeModifiers(defaults, overrides = {}) {
     } else if (overriddenKeys.includes(key)) {
       modifiers[key] = overrides[key];
     }
-  }
+  });
 
   return modifiers;
 }

--- a/tests/acceptance/many-tooltips-test.js
+++ b/tests/acceptance/many-tooltips-test.js
@@ -28,7 +28,8 @@ module('Acceptance | many-tooltips', function(hooks) {
       return acc;
     }, []);
 
-    for (const tooltip of tooltips) {
+    for(let i = 0; i < tooltips.length; i++) {
+      const tooltip = tooltips[i];
       const tooltipTarget = document.querySelector(`${tooltip}-target`);
       const tooltipOptions = {
         selector: tooltip,


### PR DESCRIPTION
`for...of` loop requires `Symbol` to exist which means it requires polyfills for older browsers like IE11 and others.

With changes in this PR `Symbol` existence is no longer a requirement.