### PR TITLE
update readme options table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 - [effect](#effect)
 - [event](#event)
 - [hideOn](#hideon)
+- [innerClass](#innerclass)
 - [isShown](#isshown)
 - [popoverHideDelay (popover only)](#popoverhidedelay)
 - [popperContainer](#poppercontainer)


### PR DESCRIPTION
Was missing `innerClass`, took me an extra 5 minutes to figure out this was a property I could adjust