### PR TITLE
Remove ember-maybe-in-element dependency

### DIFF
--- a/addon/templates/components/ember-tooltip-base.hbs
+++ b/addon/templates/components/ember-tooltip-base.hbs
@@ -1,4 +1,4 @@
-{{#maybe-in-element this._renderElement this._awaitingTooltipElementRendered}}
+{{#if this._awaitingTooltipElementRendered}}
   <div>
     {{#if this._shouldRenderContent}}
       {{#if (hasBlock)}}
@@ -8,4 +8,14 @@
       {{/if}}
     {{/if}}
   </div>
-{{/maybe-in-element}}
+{{else}}
+  {{#in-element this._renderElement}}
+    <div>
+      {{#if (hasBlock)}}
+        {{yield this}}
+      {{else}}
+        {{this.text}}
+      {{/if}}
+    </div>
+  {{/in-element}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
     "ember-in-element-polyfill": "^1.0.0",
-    "ember-maybe-in-element": "^1.0.0",
     "popper.js": "^1.12.5",
     "resolve": "^1.10.1",
     "tooltip.js": "^1.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4660,14 +4660,6 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-maybe-in-element@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-1.0.0.tgz#55fdbe3784a9807c69bf681c53926426a4a16498"
-  integrity sha512-aXYAb+u/kkZmPqjRhBNoaGAr3vZndf9Lrqy6xdPfpQ5ekM/a0oE9fAAZNg4Cq09bPecEnty4LJqAYZqS/oWvjg==
-  dependencies:
-    ember-cli-babel "^7.7.3"
-    ember-in-element-polyfill "^1.0.0"
-
 ember-named-arguments-polyfill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-named-arguments-polyfill/-/ember-named-arguments-polyfill-1.0.0.tgz#0b81fb81a7cef2c89e9e1d0278b579e708bf4ded"


### PR DESCRIPTION
`ember-maybe-in-element` was used as a quick drop-in replacement for `ember-wormhole` when the latter became problematic for more recent Ember versions. However, version 2.0.0+ of `ember-maybe-in-element` dropped support for Ember < 3.13, which this addon still supports, and uses a Glimmer-component based approach, rather than an AST transform to equivalent `in-element` calls. As raised in #406, pinning to 1.0.0 is problematic for folks using newer versions of `ember-maybe-in-element` either directly or via popular addons like `ember-basic-dropdown`.

The most compatible solution, rather than directly importing the AST transform from version 1.0, is to just use `in-element` directly. This results in a small amount of duplication, but I think it's a worthwhile trade-off (duplication that happened during build time anyway, via the `ember-maybe-in-element` AST transform)