### PR TITLE
Use "this.import" instead of "app.import" to support lazy engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@ module.exports = {
     }
   },
 
-  included: function (app) {
+  included: function () {
     this._super.included.apply(this, arguments);
 
-    app.import('vendor/ember-tooltips--popper.js', {
+    this.import(`${this.treePaths.vendor}/ember-tooltips--popper.js`, {
       using: [
         {
           transformation: 'amd',
@@ -40,7 +40,7 @@ module.exports = {
         },
       ],
     });
-    app.import('vendor/ember-tooltips--tooltip.js', {
+    this.import(`${this.treePaths.vendor}/ember-tooltips--tooltip.js`, {
       using: [
         {
           transformation: 'amd',


### PR DESCRIPTION
Fixes #363.

I'm no Ember CLI expert but this fixes the lazy engines issue for me.
Based on [this ember-cli-moment-shim commit](https://github.com/jasonmit/ember-cli-moment-shim/commit/6f3dea3c7db8d6220e8dff393c4975139ada4611).

I've also tested the following scenario's locally to ensure the imports still work properly:
- `ember-tooltips` as a dev and normal dependency of an addon
- `ember-tooltips` as a dev and normal dependency of a project
- `ember-tooltips` as a nested dependency of a project