### PR TITLE
Remove CI for Ember 2.18 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@
 #$ browsers:
 #$   - chrome
 #$ emberTryScenarios:
-#$   - scenario: ember-lts-2.18
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.4
 #$     allowedToFail: false
 #$   - scenario: ember-lts-3.8
@@ -187,7 +185,6 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario: [
-          ember-lts-2.18,
           ember-lts-3.4,
           ember-lts-3.8,
           ember-lts-3.12,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,21 +7,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-2.18',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1',
-            'ember-source': '~2.18.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.4',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Some transitive dependency update is causing the ember-try 2.18 scenario to fail CI, with an error related to `setTimeout` not being defined while trying to compile a helper in `ember-in-element-polyfill`.

Not really interested in investigating this further,cso disabling it CI for now.

Ember 2.18 LTS will continue to be supported for 3.x, but we just won't be testing against it (unless the issue resolves itself.) It's a three year-old release, and we're not planning on making any broad sweeping changes to the 3.x series, so I feel okay about not having automated tests for 2.18.