### PR TITLE
Remove `assign()` usage

### DIFF
--- a/addon/components/ember-tooltip-base.js
+++ b/addon/components/ember-tooltip-base.js
@@ -3,7 +3,6 @@ import Ember from 'ember';
 import { getOwner } from '@ember/application';
 import { computed } from '@ember/object';
 import { deprecatingAlias } from '@ember/object/computed';
-import { assign } from '@ember/polyfills';
 import { warn } from '@ember/debug';
 import { bind, cancel, run, later, scheduleOnce } from '@ember/runloop';
 import { capitalize, w } from '@ember/string';
@@ -647,11 +646,11 @@ function mergeModifiers(defaults, overrides = {}) {
     if (acc.indexOf(key) === -1) acc.push(key);
     return acc;
   }, []);
-  const modifiers = assign({}, defaults);
+  const modifiers = { ...defaults };
 
   keys.forEach((key) => {
     if (defaultKeys.indexOf(key) !== -1 && overriddenKeys.indexOf(key) !== -1) {
-      modifiers[key] = assign({}, defaults[key], overrides[key]);
+      modifiers[key] = { ...defaults[key], ...overrides[key] };
     } else if (overriddenKeys.indexOf(key) !== -1) {
       modifiers[key] = overrides[key];
     }


### PR DESCRIPTION
The `assign()` function in Ember.js has been deprecated with v4. This replaces it with the object spread syntax which should be compiled away by Babel, if necessary.

This is an alternative to and closes https://github.com/sir-dunxalot/ember-tooltips/pull/437

/cc @maxfierke 